### PR TITLE
Incorrect Icon Display for Categories

### DIFF
--- a/src/components/ui/categoryIcons.tsx
+++ b/src/components/ui/categoryIcons.tsx
@@ -18,7 +18,6 @@ import {
   Hammer,
   HandIcon,
   Home,
-  Lightbulb,
   type LucideIcon,
   Music,
   ParkingCircle,
@@ -39,6 +38,9 @@ import {
   Wine,
   Zap,
   type LucideProps,
+  Paintbrush,
+  Trash,
+  Wrench,
 } from 'lucide-react';
 import { type ForwardRefExoticComponent } from 'react';
 
@@ -76,13 +78,15 @@ export const CategoryIcons: Record<string, LucideIcon> = {
   parking: ParkingCircle,
   plane: Plane,
   taxi: CarTaxiFront,
-  utilities: Lightbulb,
+  utilities: Wrench,
   electricity: Zap,
   gas: Flame,
   internet: Globe,
   phone: Phone,
   water: GlassWater,
   general: Banknote,
+  cleaning: Paintbrush,
+  trash: Trash,
 };
 
 export const CategoryIcon: React.FC<{ category: string; className?: string }> = ({


### PR DESCRIPTION
Resolves:#64

![Screenshot 2024-10-11 at 12-59-49 Add Expense](https://github.com/user-attachments/assets/e21a1542-9a88-4d71-915e-255e15d11962)

![Screenshot 2024-10-11 at 13-00-36 Add Expense](https://github.com/user-attachments/assets/fb716868-799c-42a0-a2d0-a7aa97ee7177)

