### PR TITLE
🚀 Order by expense created date in the groups list

### DIFF
--- a/src/server/api/routers/group.ts
+++ b/src/server/api/routers/group.ts
@@ -60,12 +60,24 @@ export const groupRouter = createTRPCRouter({
             groupBalances: {
               where: { userId: ctx.session.user.id },
             },
+            expenses: {
+              orderBy: {
+                createdAt: 'desc',
+              },
+              take: 1,
+            },
           },
         },
       },
     });
 
-    const groupsWithBalances = groups.map((g) => {
+    const sortedGroupsByLatestExpense = groups.sort((a, b) => {
+      const aDate = a.group.expenses[0]?.createdAt ?? new Date(0);
+      const bDate = b.group.expenses[0]?.createdAt ?? new Date(0);
+      return bDate.getTime() - aDate.getTime();
+    });
+
+    const groupsWithBalances = sortedGroupsByLatestExpense.map((g) => {
       const balances: Record<string, number> = {};
 
       for (const balance of g.group.groupBalances) {


### PR DESCRIPTION
Orders the groups on the group page so its based on the groups latest expense.
Before the groups were rendered in the default orderby which was order by id. Now it's ordered by the groups latest expense.

Related to this: https://github.com/oss-apps/split-pro/issues/138