### PR TITLE
🚀 Redirect to groupexpense or expense in activity list based on groupId

### DIFF
--- a/src/pages/activity.tsx
+++ b/src/pages/activity.tsx
@@ -66,7 +66,11 @@ const ActivityPage: NextPageWithUser = ({ user }) => {
                   <div className="mt-[30vh] text-center text-gray-400">No activities yet</div>
                 ) : null}
                 {expensesQuery.data?.map((e) => (
-                  <Link href={`/expenses/${e.expenseId}`} key={e.expenseId} className="flex  gap-2">
+                  <Link
+                    href={`${e.expense.groupId ? `/groups/${e.expense.groupId}/` : '/'}expenses/${e.expenseId}`}
+                    key={e.expenseId}
+                    className="flex  gap-2"
+                  >
                     <div className="mt-1">
                       <UserAvatar user={e.expense.paidByUser} size={30} />
                     </div>


### PR DESCRIPTION
Redirect the user to the group expense page instead of the expense page if its a group expense.

May be related to: https://github.com/oss-apps/split-pro/issues/130