### PR TITLE
🚀 Add group created date and first expense date

### DIFF
--- a/src/pages/groups/[groupId].tsx
+++ b/src/pages/groups/[groupId].tsx
@@ -163,6 +163,17 @@ const BalancePage: NextPageWithUser<{
                     ) : null;
                   })}
                 </div>
+                {expensesQuery?.data && expensesQuery?.data?.length > 0 && (
+                  <div className="mt-8">
+                    <p className="font-semibold">First expense</p>
+                    <p>
+                      {format(
+                        expensesQuery.data[expensesQuery.data.length - 1]?.createdAt ?? new Date(),
+                        'yyyy-MM-dd',
+                      )}
+                    </p>
+                  </div>
+                )}
               </div>
             </AppDrawer>
             <AppDrawer
@@ -184,6 +195,12 @@ const BalancePage: NextPageWithUser<{
                   ))}
                 </div>
               </div>
+              {groupDetailQuery?.data?.createdAt && (
+                <div className="mt-8">
+                  <p className="font-semibold ">Group created</p>
+                  <p>{format(groupDetailQuery.data?.createdAt, 'yyyy-MM-dd')}</p>
+                </div>
+              )}
               <div className="mt-8">
                 <p className="font-semibold ">Actions</p>
                 <div className="mt-2 flex flex-col gap-1">

--- a/src/pages/groups/[groupId].tsx
+++ b/src/pages/groups/[groupId].tsx
@@ -168,7 +168,9 @@ const BalancePage: NextPageWithUser<{
                     <p className="font-semibold">First expense</p>
                     <p>
                       {format(
-                        expensesQuery.data[expensesQuery.data.length - 1]?.createdAt ?? new Date(),
+                        new Date(
+                          expensesQuery.data[expensesQuery.data.length - 1]?.createdAt ?? '',
+                        ).toLocaleDateString(),
                         'yyyy-MM-dd',
                       )}
                     </p>
@@ -198,7 +200,12 @@ const BalancePage: NextPageWithUser<{
               {groupDetailQuery?.data?.createdAt && (
                 <div className="mt-8">
                   <p className="font-semibold ">Group created</p>
-                  <p>{format(groupDetailQuery.data?.createdAt, 'yyyy-MM-dd')}</p>
+                  <p>
+                    {format(
+                      new Date(groupDetailQuery.data?.createdAt).toLocaleDateString(),
+                      'yyyy-MM-dd',
+                    )}
+                  </p>
                 </div>
               )}
               <div className="mt-8">


### PR DESCRIPTION
- Added the group created date to group info panel.
- Added the groups first expense date in the groups statistics panel.

Screenshots:

<img width="494" alt="image" src="https://github.com/user-attachments/assets/9e88af5b-ba64-4703-8ba3-78fd2e4c3515">
<img width="498" alt="image" src="https://github.com/user-attachments/assets/bb504e6f-0d49-42d3-9abf-10e6206c3efe">