### PR TITLE
fix: prevent sending an invite email if not enabled

### DIFF
--- a/src/server/mailer.ts
+++ b/src/server/mailer.ts
@@ -52,6 +52,10 @@ export async function sendSignUpEmail(email: string, token: string, url: string)
 }
 
 export async function sendInviteEmail(email: string, name: string) {
+  if (!env.ENABLE_SENDING_INVITES) {
+    throw new Error("Sending invites is not enabled")
+  }
+
   const { host } = new URL(env.NEXTAUTH_URL);
 
   if (env.NODE_ENV === 'development') {


### PR DESCRIPTION
this updates the invite email sending function to prevent sending an invite email if the environment flag is not set.  this matches the behavior with the frontend and prevents malicious actors from bypassing the logic

fixes #174