### PR TITLE
bugfix/issue-217-web-push-in-docker-image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,7 @@ AUTHENTIK_ISSUER=
 
 # Push notification, Web Push: https://www.npmjs.com/package/web-push
 # generate web push keys using this command: web-push generate-vapid-keys --json
+# when using docker use this command: docker compose exec splitpro npx web-push generate-vapid-keys --json
 WEB_PUSH_PRIVATE_KEY=
 WEB_PUSH_PUBLIC_KEY=
 WEB_PUSH_EMAIL=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,14 @@ COPY --from=base  /app/node_modules/sharp ./node_modules/sharp
 RUN mkdir node_modules/.bin
 RUN ln -s /app/node_modules/prisma/build/index.js ./node_modules/.bin/prisma
 
+COPY --from=base  /app/node_modules/web-push ./node_modules/web-push
+COPY --from=base  /app/node_modules/.pnpm/web-push@3.6.7 ./node_modules/.pnpm/web-push@3.6.7
+# Required dependency for web-push
+COPY --from=base  /app/node_modules/.pnpm/minimist@1.2.8 ./node_modules/.pnpm/minimist@1.2.8
+
+# Symlink the web-push binary
+RUN ln -s /app/node_modules/web-push/src/cli.js ./node_modules/.bin/web-push
+
 # set this so it throws error where starting server
 ENV SKIP_ENV_VALIDATION="false"
 


### PR DESCRIPTION
In Issue #217 I noticed that `web-push` is not present in the docker image which prevented me from using push notifications. I guess due to shrinking the image size the multi-stage docker build installs all packages in the `base` stage and then copies only necessary files to the `release` stage.

See `Dockerfile`:
```Dockerfile
COPY --from=base  /app/prisma/schema.prisma ./prisma/schema.prisma
COPY --from=base  /app/prisma/migrations ./prisma/migrations
COPY --from=base  /app/node_modules/prisma ./node_modules/prisma
COPY --from=base  /app/node_modules/@prisma ./node_modules/@prisma
COPY --from=base  /app/node_modules/sharp ./node_modules/sharp
```

But this results in `web-push` not being available inside the `release` stage, so I added these lines that copy `web-push` and the `pnpm` dependencies of it.:
```Dockerfile
COPY --from=base  /app/node_modules/web-push ./node_modules/web-push
COPY --from=base  /app/node_modules/.pnpm/web-push@3.6.7 ./node_modules/.pnpm/web-push@3.6.7
```

For `web-push` to be runnable you also have to symlink the binary to `node_modules` similar to how the `prisma` binary was linked:
```Dockerfile
# Symlink the web-push binary
RUN ln -s /app/node_modules/web-push/src/cli.js ./node_modules/.bin/web-push
```

I would think that it now works but when running `npx web-push` inside the container, you get an error that the required dependency `minimist` is not present. So I copied it too:
```Dockerfile
# Required dependency for web-push
COPY --from=base  /app/node_modules/.pnpm/minimist@1.2.8 ./node_modules/.pnpm/minimist@1.2.8
```

I also added a short comment to `.env.example` on how to generate `web-push` keys when using docker.
I hope you like my solution, thank you for developing splitpro!