### PR TITLE
Add BigInt JSON replacer for account data export

### DIFF
--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -22,6 +22,9 @@ import { AppDrawer } from '~/components/ui/drawer';
 import { LoadingSpinner } from '~/components/ui/spinner';
 import { type NextPageWithUser } from '~/types';
 import { api } from '~/utils/api';
+import { bigIntReplacer } from '~/utils/numbers';
+
+
 
 const AccountPage: NextPageWithUser = ({ user }) => {
   const userQuery = api.user.me.useQuery();
@@ -33,7 +36,7 @@ const AccountPage: NextPageWithUser = ({ user }) => {
   const downloadData = useCallback(async () => {
     setDownloading(true);
     const data = await downloadQuery.mutateAsync();
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+    const blob = new Blob([JSON.stringify(data, bigIntReplacer, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -24,8 +24,6 @@ import { type NextPageWithUser } from '~/types';
 import { api } from '~/utils/api';
 import { bigIntReplacer } from '~/utils/numbers';
 
-
-
 const AccountPage: NextPageWithUser = ({ user }) => {
   const userQuery = api.user.me.useQuery();
   const downloadQuery = api.user.downloadData.useMutation();

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -86,3 +86,7 @@ export const BigMath = {
     }
   },
 };
+
+export const bigIntReplacer = (key: string, value: any) => {
+  return typeof value === 'bigint' ? value.toString() : value;
+};

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -87,6 +87,6 @@ export const BigMath = {
   },
 };
 
-export const bigIntReplacer = (key: string, value: any) => {
+export const bigIntReplacer = (key: string, value: any): unknown => {
   return typeof value === 'bigint' ? value.toString() : value;
 };


### PR DESCRIPTION
You can't serialize BigiInt. So I added a bigIntReplacer function to serialize BigInt values as strings in JSON output.