### PR TITLE
Fix 221 dont use nextjs config redirect

### DIFF
--- a/docker/prod/compose.yml
+++ b/docker/prod/compose.yml
@@ -52,6 +52,7 @@ services:
       - WEB_PUSH_EMAIL=${WEB_PUSH_EMAIL}
       - FEEDBACK_EMAIL=${FEEDBACK_EMAIL}
       - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
+      - DEFAULT_HOMEPAGE=${DEFAULT_HOMEPAGE}
     depends_on:
       postgres:
         condition: service_healthy

--- a/next.config.js
+++ b/next.config.js
@@ -32,13 +32,6 @@ const config = {
     defaultLocale: 'en',
   },
   transpilePackages: ['geist'],
-  redirects: async () => [
-    {
-      source: '/',
-      destination: process.env.DEFAULT_HOMEPAGE ?? '/home',
-      permanent: true,
-    },
-  ],
   images: {
     remotePatterns: [
       {

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,16 @@
+import { type GetServerSideProps } from 'next';
+
+import { env } from '~/env';
+
+export default function Home() {
+  return null;
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    redirect: {
+      destination: env.DEFAULT_HOMEPAGE,
+      permanent: true,
+    },
+  };
+};


### PR DESCRIPTION
I didn't properly check the Docker version and realized that next.config.js is only evaluated at build time.