### PR TITLE
Include localePath in full config

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,11 +1,13 @@
-/** @type {import('next-i18next').UserConfig} */
+import { resolve } from 'path';
+
+/** @type {import('next').NextConfig} */
 const config = {
   i18n: {
     defaultLocale: 'default',
     locales: ['default', 'en', 'de', 'it', 'pl', 'pt', 'sv'],
     localeDetection: false,
   },
-  localePath: './public/locales',
+  localePath: resolve('./public/locales'),
 };
 
 export default config;

--- a/next.config.js
+++ b/next.config.js
@@ -16,7 +16,7 @@ const nextConfig = {
    *
    * @see https://github.com/vercel/next.js/issues/41980
    */
-  i18n: i18nConfig.i18n,
+  ...i18nConfig,
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
Related to #340 

Can't reproduce so don't know if it's the solution, but I found this thread: https://stackoverflow.com/questions/69656025/next-i18next-is-not-working-with-serversideprops-in-dynamic-pages-after-deployin
and noticed we aren't actually using the localePath