### PR TITLE
Fix the number of weeks in calendar

### DIFF
--- a/src/components/AddExpense/AddExpensePage.tsx
+++ b/src/components/AddExpense/AddExpensePage.tsx
@@ -236,8 +236,13 @@ export const AddOrEditExpensePage: React.FC<{
                           )}
                         </Button>
                       </PopoverTrigger>
-                      <PopoverContent className="w-auto p-0">
-                        <Calendar mode="single" selected={expenseDate} onSelect={setExpenseDate} />
+                      <PopoverContent align="center" className="w-auto p-0">
+                        <Calendar
+                          fixedWeeks
+                          mode="single"
+                          selected={expenseDate}
+                          onSelect={setExpenseDate}
+                        />
                       </PopoverContent>
                     </Popover>
                   </div>

--- a/src/components/AddExpense/AddExpensePage.tsx
+++ b/src/components/AddExpense/AddExpensePage.tsx
@@ -236,7 +236,7 @@ export const AddOrEditExpensePage: React.FC<{
                           )}
                         </Button>
                       </PopoverTrigger>
-                      <PopoverContent align="center" className="w-auto p-0">
+                      <PopoverContent className="w-auto p-0">
                         <Calendar
                           fixedWeeks
                           mode="single"


### PR DESCRIPTION
Closes #345 by fixing the number of weeks in the calendar to the maximum of 6 and thus preventing size fluctuations