### PR TITLE
feat: Add Spanish (Mexico) and Spanish (Argentina) locales

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -2,7 +2,7 @@
 const config = {
   i18n: {
     defaultLocale: 'default',
-    locales: ['default', 'en', 'de', 'it', 'pl', 'pt', 'sv'],
+    locales: ['default', 'en', 'de', 'it', 'pl', 'pt', 'sv', 'es-MX', 'es-AR'],
     localeDetection: false,
   },
   localePath: './public/locales',

--- a/public/locales/es-AR/account_page.json
+++ b/public/locales/es-AR/account_page.json
@@ -1,0 +1,74 @@
+{
+  "ui": {
+    "title": "Cuenta",
+    "change_language": "Cambiar idioma",
+    "change_language_details": {
+      "title": "Seleccionar un idioma",
+      "messages": {
+        "language_changed": "Idioma cambiado exitosamente"
+      },
+      "errors": {
+        "language_change_failed": "Error al cambiar el idioma"
+      },
+      "placeholder": "Seleccionar un idioma"
+    },
+    "notifications": {
+      "enable_notification": "Habilitar notificaciones",
+      "disable_notification": "Deshabilitar notificaciones",
+      "messages": {
+        "notification_granted": "Ahora recibirás notificaciones"
+      },
+      "errors": {
+        "notification_not_supported": "Las notificaciones no son compatibles",
+        "subscribe_error": "No se puede suscribir a las notificaciones",
+        "unsubscribe_error": "Error al cancelar la suscripción a las notificaciones",
+        "request_error": "Error al solicitar notificaciones"
+      }
+    },
+    "download_app": "Descargar aplicación",
+    "download_app_details": {
+      "title": "Descargar aplicación",
+      "download_as_pwa": "Podés descargar SplitPro como una PWA a tu pantalla de inicio.",
+      "using_ios": "Si usás iOS, revisá este",
+      "using_android": "Si usás Android, revisá este",
+      "video": "video"
+    },
+    "import_from_splitwise": "Importar desde Splitwise",
+    "import_from_splitwise_details": {
+      "choose_file": "Elegir archivo",
+      "no_file_chosen": "Ningún archivo seleccionado",
+      "note": "Nota: Actualmente solo soporta la importación de amigos y grupos. No importará transacciones. Estamos trabajando en ello.",
+      "follow_to_export_splitwise_data": "Seguí este enlace para exportar datos de Splitwise",
+      "export_splitwise_data_button": "Exportar datos de Splitwise",
+      "messages": {
+        "import_success": "Importación exitosa"
+      },
+      "errors": {
+        "import_failed": "Error al importar el archivo"
+      }
+    },
+    "download_splitpro_data": "Descargar datos de SplitPro",
+    "submit_feedback": "Enviar comentarios",
+    "submit_feedback_details": {
+      "title": "Enviar comentarios",
+      "placeholder": "Ingresá tus comentarios"
+    },
+    "errors": {
+      "feedback_required": "Los comentarios son obligatorios",
+      "feedback_min_length": "Los comentarios deben tener al menos 10 caracteres"
+    },
+    "messages": {
+      "submit_success": "Comentarios enviados",
+      "submit_error": "Error al enviar los comentarios"
+    },
+    "write_review": "Escribir una reseña",
+    "star_on_github": "Danos una estrella en GitHub",
+    "support_us": "Patrocinanos",
+    "follow_on_x": "Seguinos en X",
+    "logout": "Cerrar sesión",
+    "edit_name": {
+      "title": "Editar nombre",
+      "placeholder": "Ingresá el nombre"
+    }
+  }
+}

--- a/public/locales/es-AR/categories.json
+++ b/public/locales/es-AR/categories.json
@@ -1,0 +1,86 @@
+{
+  "title": "Categorías",
+  "categories_list": {
+    "entertainment": {
+      "name": "Entretenimiento",
+      "items": {
+        "games": "Juegos",
+        "movies": "Películas",
+        "music": "Música",
+        "sports": "Deportes",
+        "other": "Entretenimiento"
+      }
+    },
+    "food": {
+      "name": "Comida y Bebidas",
+      "items": {
+        "diningOut": "Comer afuera",
+        "groceries": "Comestibles",
+        "liquor": "Bebidas alcohólicas",
+        "other": "Comida y Bebidas"
+      }
+    },
+    "home": {
+      "name": "Hogar",
+      "items": {
+        "electronics": "Electrónica",
+        "furniture": "Muebles",
+        "supplies": "Suministros",
+        "maintenance": "Mantenimiento",
+        "mortgage": "Hipoteca",
+        "pets": "Mascotas",
+        "rent": "Alquiler",
+        "services": "Servicios",
+        "other": "Hogar"
+      }
+    },
+    "life": {
+      "name": "Vida",
+      "items": {
+        "childcare": "Cuidado de niños",
+        "clothing": "Ropa",
+        "education": "Educación",
+        "gifts": "Regalos",
+        "medical": "Médico",
+        "taxes": "Impuestos",
+        "other": "Vida",
+        "insurance": "Seguro"
+      }
+    },
+    "travel": {
+      "name": "Viajes",
+      "items": {
+        "bus": "Colectivo",
+        "train": "Tren",
+        "car": "Auto",
+        "fuel": "Combustible",
+        "parking": "Estacionamiento",
+        "plane": "Avión",
+        "taxi": "Taxi",
+        "other": "Viajes",
+        "bicycle": "Bicicleta",
+        "hotel": "Hotel"
+      }
+    },
+    "utilities": {
+      "name": "Servicios",
+      "items": {
+        "cleaning": "Limpieza",
+        "electricity": "Electricidad",
+        "gas": "Gas",
+        "internet": "Internet",
+        "trash": "Basura",
+        "phone": "Teléfono",
+        "water": "Agua",
+        "other": "Servicios"
+      }
+    },
+    "general": {
+      "name": "General",
+      "items": {
+        "general": "General",
+        "other": "General"
+      }
+    }
+  }
+}

--- a/public/locales/es-AR/common.json
+++ b/public/locales/es-AR/common.json
@@ -1,0 +1,92 @@
+{
+  "meta": {
+    "title": "SplitPro: Dividí gastos con tus amigos gratis",
+    "description": "Dividí gastos con tus amigos gratis",
+    "application_name": "SplitPro"
+  },
+  "navigation": {
+    "app_name": "SplitPro",
+    "balances": "Saldos",
+    "groups": "Grupos",
+    "add_expense": "Agregar Gasto",
+    "add": "Agregar",
+    "activity": "Actividad",
+    "account": "Cuenta"
+  },
+  "ui": {
+    "actors": {
+      "you": "Vos",
+      "you_dativus": "A vos",
+      "you_accusativus": "A vos",
+      "friends": "Amigos",
+      "groups": "Grupos",
+      "members": "Miembros",
+      "owner": "Propietario",
+      "all": "Todos"
+    },
+    "actions": {
+      "cancel": "Cancelar",
+      "confirm": "Confirmar",
+      "submit": "Enviar",
+      "close": "Cerrar",
+      "back": "Volver",
+      "create": "Crear",
+      "save": "Guardar",
+      "leave": "Salir",
+      "invite": "Invitar",
+      "export": "Exportar",
+      "import": "Importar",
+      "add_expense": "Agregar gasto",
+      "edit_expense": "Editar gasto",
+      "settle_up": "Liquidar"
+    },
+    "expense": {
+      "you": {
+        "lent": "prestaste",
+        "owe": "debés",
+        "paid": "pagaste",
+        "pay": "pagar",
+        "received": "recibiste",
+        "deleted": "eliminaste"
+      },
+      "user": {
+        "lent": "prestó",
+        "owe": "debe",
+        "paid": "pagó",
+        "pay": "paga",
+        "received": "recibió",
+        "deleted": "eliminó"
+      },
+      "for": "para",
+      "paid_by": "Pagado por",
+      "received_by": "Recibido por",
+      "to": "a",
+      "from": "de"
+    },
+    "balance": "saldo",
+    "balances": "saldos",
+    "or": "o",
+    "and": "y",
+    "today": "Hoy",
+    "delete": "Eliminar",
+    "edited_by": "Editado por",
+    "deleted_by": "Eliminado por",
+    "added_by": "Agregado por",
+    "on": "el",
+    "not_involved": "No involucrado",
+    "no_activity": "Aún no hay actividades",
+    "settled_up": "Liquidado",
+    "settle_up_name": "Liquidar",
+    "settlement": "Liquidación",
+    "expense_details": "Detalles del gasto",
+    "select_currency": "Seleccionar moneda",
+    "outstanding_balances": "Saldos pendientes",
+    "share_text": "Echale un vistazo a SplitPro. Es una alternativa gratuita de código abierto a Splitwise"
+  },
+  "errors": {
+    "name_required": "El nombre es requerido",
+    "saving_expense": "Error al guardar el gasto",
+    "something_went_wrong": "Algo salió mal",
+    "valid_email": "Ingresá un correo electrónico válido"
+  }
+}

--- a/public/locales/es-AR/currencies.json
+++ b/public/locales/es-AR/currencies.json
@@ -1,0 +1,559 @@
+{
+  "title": "Seleccionar moneda",
+  "placeholder": "Seleccionar moneda",
+  "no_currency_found": "No se encontró ninguna moneda.",
+  "currency_list": {
+    "CAD": {
+      "name": "Dólar Canadiense",
+      "name_plural": "Dólares canadienses"
+    },
+    "EUR": {
+      "name": "Euro",
+      "name_plural": "Euros"
+    },
+    "AED": {
+      "name": "Dirham de los Emiratos Árabes Unidos",
+      "name_plural": "Dirhams de los EAU"
+    },
+    "AFN": {
+      "name": "Afgani Afgano",
+      "name_plural": "Afganis afganos"
+    },
+    "ALL": {
+      "name": "Lek Albanés",
+      "name_plural": "Lekë albaneses"
+    },
+    "AMD": {
+      "name": "Dram Armenio",
+      "name_plural": "Drams armenios"
+    },
+    "ARS": {
+      "name": "Peso Argentino",
+      "name_plural": "Pesos argentinos"
+    },
+    "AUD": {
+      "name": "Dólar Australiano",
+      "name_plural": "Dólares australianos"
+    },
+    "AZN": {
+      "name": "Manat Azerbaiyano",
+      "name_plural": "Manats azerbaiyanos"
+    },
+    "BAM": {
+      "name": "Marco Convertible de Bosnia y Herzegovina",
+      "name_plural": "Marcos convertibles de Bosnia y Herzegovina"
+    },
+    "BDT": {
+      "name": "Taka Bangladesí",
+      "name_plural": "Takas bangladesíes"
+    },
+    "BGN": {
+      "name": "Lev Búlgaro",
+      "name_plural": "Leva búlgaros"
+    },
+    "BHD": {
+      "name": "Dinar Bahreiní",
+      "name_plural": "Dinares bahreiníes"
+    },
+    "BIF": {
+      "name": "Franco Burundés",
+      "name_plural": "Francos burundeses"
+    },
+    "BND": {
+      "name": "Dólar de Brunéi",
+      "name_plural": "Dólares de Brunéi"
+    },
+    "BOB": {
+      "name": "Boliviano Boliviano",
+      "name_plural": "Bolivianos bolivianos"
+    },
+    "BRL": {
+      "name": "Real Brasileño",
+      "name_plural": "Reales brasileños"
+    },
+    "BWP": {
+      "name": "Pula Botswanés",
+      "name_plural": "Pulas botswanéses"
+    },
+    "BYN": {
+      "name": "Rublo Bielorruso",
+      "name_plural": "Rublos bielorrusos"
+    },
+    "BZD": {
+      "name": "Dólar Beliceño",
+      "name_plural": "Dólares beliceños"
+    },
+    "CDF": {
+      "name": "Franco Congoleño",
+      "name_plural": "Francos congoleños"
+    },
+    "CHF": {
+      "name": "Franco Suizo",
+      "name_plural": "Francos suizos"
+    },
+    "CLP": {
+      "name": "Peso Chileno",
+      "name_plural": "Pesos chilenos"
+    },
+    "CNY": {
+      "name": "Yuan Chino",
+      "name_plural": "Yuanes chinos"
+    },
+    "COP": {
+      "name": "Peso Colombiano",
+      "name_plural": "Pesos colombianos"
+    },
+    "CRC": {
+      "name": "Colón Costarricense",
+      "name_plural": "Colones costarricenses"
+    },
+    "CVE": {
+      "name": "Escudo Caboverdiano",
+      "name_plural": "Escudos caboverdianos"
+    },
+    "CZK": {
+      "name": "Corona Checa",
+      "name_plural": "Coronas checas"
+    },
+    "DJF": {
+      "name": "Franco Yibutiano",
+      "name_plural": "Francos yibutianos"
+    },
+    "DKK": {
+      "name": "Corona Danesa",
+      "name_plural": "Coronas danesas"
+    },
+    "DOP": {
+      "name": "Peso Dominicano",
+      "name_plural": "Pesos dominicanos"
+    },
+    "DZD": {
+      "name": "Dinar Argelino",
+      "name_plural": "Dinares argelinos"
+    },
+    "EEK": {
+      "name": "Corona Estonia",
+      "name_plural": "Coronas estonias"
+    },
+    "EGP": {
+      "name": "Libra Egipcia",
+      "name_plural": "Libras egipcias"
+    },
+    "ERN": {
+      "name": "Nakfa Eritreo",
+      "name_plural": "Nakfas eritreos"
+    },
+    "ETB": {
+      "name": "Birr Etíope",
+      "name_plural": "Birrs etíopes"
+    },
+    "GBP": {
+      "name": "Libra Esterlina Británica",
+      "name_plural": "Libras esterlinas británicas"
+    },
+    "GEL": {
+      "name": "Lari Georgiano",
+      "name_plural": "Laris georgianos"
+    },
+    "GHS": {
+      "name": "Cedi Ghanés",
+      "name_plural": "Cedis ghaneses"
+    },
+    "GNF": {
+      "name": "Franco Guineano",
+      "name_plural": "Francos guineanos"
+    },
+    "GTQ": {
+      "name": "Quetzal Guatemalteco",
+      "name_plural": "Quetzales guatemaltecos"
+    },
+    "HKD": {
+      "name": "Dólar de Hong Kong",
+      "name_plural": "Dólares de Hong Kong"
+    },
+    "HNL": {
+      "name": "Lempira Hondureña",
+      "name_plural": "Lempiras hondureñas"
+    },
+    "HRK": {
+      "name": "Kuna Croata",
+      "name_plural": "Kunas croatas"
+    },
+    "HUF": {
+      "name": "Forint Húngaro",
+      "name_plural": "Forints húngaros"
+    },
+    "IDR": {
+      "name": "Rupia Indonesia",
+      "name_plural": "Rupias indonesias"
+    },
+    "ILS": {
+      "name": "Nuevo Shekel Israelí",
+      "name_plural": "Nuevos shekels israelíes"
+    },
+    "INR": {
+      "name": "Rupia India",
+      "name_plural": "Rupias indias"
+    },
+    "IQD": {
+      "name": "Dinar Iraquí",
+      "name_plural": "Dinares iraquíes"
+    },
+    "IRR": {
+      "name": "Rial Iraní",
+      "name_plural": "Riales iraníes"
+    },
+    "ISK": {
+      "name": "Corona Islandesa",
+      "name_plural": "Coronas islandesas"
+    },
+    "JMD": {
+      "name": "Dólar Jamaicano",
+      "name_plural": "Dólares jamaicanos"
+    },
+    "JOD": {
+      "name": "Dinar Jordano",
+      "name_plural": "Dinares jordanos"
+    },
+    "JPY": {
+      "name": "Yen Japonés",
+      "name_plural": "Yenes japoneses"
+    },
+    "KES": {
+      "name": "Chelín Keniano",
+      "name_plural": "Chelines kenianos"
+    },
+    "KHR": {
+      "name": "Riel Camboyano",
+      "name_plural": "Rieles camboyanos"
+    },
+    "KMF": {
+      "name": "Franco Comorense",
+      "name_plural": "Francos comorenses"
+    },
+    "KRW": {
+      "name": "Won Surcoreano",
+      "name_plural": "Wones surcoreanos"
+    },
+    "KWD": {
+      "name": "Dinar Kuwaití",
+      "name_plural": "Dinares kuwaitíes"
+    },
+    "KZT": {
+      "name": "Tenge Kazajo",
+      "name_plural": "Tenges kazajos"
+    },
+    "LAK": {
+      "name": "Kip Lao",
+      "name_plural": "Kips laosianos"
+    },
+    "LBP": {
+      "name": "Libra Libanesa",
+      "name_plural": "Libras libanesas"
+    },
+    "LKR": {
+      "name": "Rupia de Sri Lanka",
+      "name_plural": "Rupias de Sri Lanka"
+    },
+    "LRD": {
+      "name": "Dólar Liberiano",
+      "name_plural": "Dólares liberianos"
+    },
+    "LSL": {
+      "name": "Loti Lesotense",
+      "name_plural": "Lotis lesotenses"
+    },
+    "LYD": {
+      "name": "Dinar Libio",
+      "name_plural": "Dinares libios"
+    },
+    "MAD": {
+      "name": "Dirham Marroquí",
+      "name_plural": "Dirhams marroquíes"
+    },
+    "MDL": {
+      "name": "Leu Moldavo",
+      "name_plural": "Lei moldavos"
+    },
+    "MGA": {
+      "name": "Ariary Malgache",
+      "name_plural": "Ariaries malgaches"
+    },
+    "MKD": {
+      "name": "Denar Macedonio",
+      "name_plural": "Denari macedonios"
+    },
+    "MMK": {
+      "name": "Kyat Birmano",
+      "name_plural": "Kyats birmanos"
+    },
+    "MNT": {
+      "name": "Tugrik Mongol",
+      "name_plural": "Tugriks mongoles"
+    },
+    "MOP": {
+      "name": "Pataca de Macao",
+      "name_plural": "Patacas de Macao"
+    },
+    "MUR": {
+      "name": "Rupia Mauriciana",
+      "name_plural": "Rupias mauricianas"
+    },
+    "MVR": {
+      "name": "Rufiyaa Maldiva",
+      "name_plural": "Rufiyaas maldivas"
+    },
+    "MWK": {
+      "name": "Kwacha Malauí",
+      "name_plural": "Kwacha malauíes"
+    },
+    "MXN": {
+      "name": "Peso Mexicano",
+      "name_plural": "Pesos mexicanos"
+    },
+    "MYR": {
+      "name": "Ringgit Malayo",
+      "name_plural": "Ringgits malayos"
+    },
+    "MZN": {
+      "name": "Metical Mozambiqueño",
+      "name_plural": "Meticales mozambiqueños"
+    },
+    "NAD": {
+      "name": "Dólar Namibio",
+      "name_plural": "Dólares namibios"
+    },
+    "NGN": {
+      "name": "Naira Nigeriana",
+      "name_plural": "Nairas nigerianas"
+    },
+    "NIO": {
+      "name": "Córdoba Nicaragüense",
+      "name_plural": "Córdobas nicaragüenses"
+    },
+    "NOK": {
+      "name": "Corona Noruega",
+      "name_plural": "Coronas noruegas"
+    },
+    "NPR": {
+      "name": "Rupia Nepalí",
+      "name_plural": "Rupias nepalíes"
+    },
+    "NZD": {
+      "name": "Dólar Neozelandés",
+      "name_plural": "Dólares neozelandeses"
+    },
+    "OMR": {
+      "name": "Rial Omaní",
+      "name_plural": "Riales omaníes"
+    },
+    "PAB": {
+      "name": "Balboa Panameño",
+      "name_plural": "Balboas panameños"
+    },
+    "PEN": {
+      "name": "Nuevo Sol Peruano",
+      "name_plural": "Nuevos soles peruanos"
+    },
+    "PGK": {
+      "name": "Kina de Papúa Nueva Guinea",
+      "name_plural": "Kinas de Papúa Nueva Guinea"
+    },
+    "PHP": {
+      "name": "Peso Filipino",
+      "name_plural": "Pesos filipinos"
+    },
+    "PKR": {
+      "name": "Rupia Pakistaní",
+      "name_plural": "Rupias pakistaníes"
+    },
+    "PLN": {
+      "name": "Zloty Polaco",
+      "name_plural": "Zlotys polacos"
+    },
+    "PYG": {
+      "name": "Guaraní Paraguayo",
+      "name_plural": "Guaraníes paraguayos"
+    },
+    "QAR": {
+      "name": "Rial Qatarí",
+      "name_plural": "Riales qataríes"
+    },
+    "RON": {
+      "name": "Leu Rumano",
+      "name_plural": "Lei rumanos"
+    },
+    "RSD": {
+      "name": "Dinar Serbio",
+      "name_plural": "Dinares serbios"
+    },
+    "RUB": {
+      "name": "Rublo Ruso",
+      "name_plural": "Rublos rusos"
+    },
+    "RWF": {
+      "name": "Franco Ruandés",
+      "name_plural": "Francos ruandeses"
+    },
+    "SAR": {
+      "name": "Riyal Saudí",
+      "name_plural": "Riyales saudíes"
+    },
+    "SBD": {
+      "name": "Dólar de las Islas Salomón",
+      "name_plural": "Dólares de las Islas Salomón"
+    },
+    "SCR": {
+      "name": "Rupia Seychellense",
+      "name_plural": "Rupias seychellenses"
+    },
+    "SDG": {
+      "name": "Libra Sudanesa",
+      "name_plural": "Libras sudanesas"
+    },
+    "SEK": {
+      "name": "Corona Sueca",
+      "name_plural": "Coronas suecas"
+    },
+    "SGD": {
+      "name": "Dólar de Singapur",
+      "name_plural": "Dólares de Singapur"
+    },
+    "SHP": {
+      "name": "Libra de Santa Elena",
+      "name_plural": "Libras de Santa Elena"
+    },
+    "SLL": {
+      "name": "Leone de Sierra Leona",
+      "name_plural": "Leones de Sierra Leona"
+    },
+    "SOS": {
+      "name": "Chelín Somalí",
+      "name_plural": "Chelines somalíes"
+    },
+    "SRD": {
+      "name": "Dólar Surinamés",
+      "name_plural": "Dólares surinameses"
+    },
+    "SSP": {
+      "name": "Libra Sudanesa del Sur",
+      "name_plural": "Libras sudanesas del sur"
+    },
+    "STD": {
+      "name": "Dobra de Santo Tomé y Príncipe",
+      "name_plural": "Dobras de Santo Tomé y Príncipe"
+    },
+    "SYP": {
+      "name": "Libra Siria",
+      "name_plural": "Libras sirias"
+    },
+    "SZL": {
+      "name": "Lilangeni Suazi",
+      "name_plural": "Emalangeni suazis"
+    },
+    "THB": {
+      "name": "Baht Tailandés",
+      "name_plural": "Baht tailandeses"
+    },
+    "TJS": {
+      "name": "Somoni Tayiko",
+      "name_plural": "Somonis tayikos"
+    },
+    "TMT": {
+      "name": "Manat Turcomano",
+      "name_plural": "Manats turcomanos"
+    },
+    "TND": {
+      "name": "Dinar Tunecino",
+      "name_plural": "Dinares tunecinos"
+    },
+    "TOP": {
+      "name": "Paʻanga Tongano",
+      "name_plural": "Paʻangas tonganos"
+    },
+    "TRY": {
+      "name": "Lira Turca",
+      "name_plural": "Liras turcas"
+    },
+    "TTD": {
+      "name": "Dólar de Trinidad y Tobago",
+      "name_plural": "Dólares de Trinidad y Tobago"
+    },
+    "TWD": {
+      "name": "Nuevo Dólar Taiwanés",
+      "name_plural": "Nuevos dólares taiwaneses"
+    },
+    "TZS": {
+      "name": "Chelín Tanzano",
+      "name_plural": "Chelines tanzanos"
+    },
+    "UAH": {
+      "name": "Grivna Ucraniana",
+      "name_plural": "Grivnas ucranianas"
+    },
+    "UGX": {
+      "name": "Chelín Ugandés",
+      "name_plural": "Chelines ugandeses"
+    },
+    "USD": {
+      "name": "Dólar Estadounidense",
+      "name_plural": "Dólares estadounidenses"
+    },
+    "UYU": {
+      "name": "Peso Uruguayo",
+      "name_plural": "Pesos uruguayos"
+    },
+    "UZS": {
+      "name": "Som Uzbeko",
+      "name_plural": "Soms uzbekos"
+    },
+    "VEF": {
+      "name": "Bolívar Venezolano",
+      "name_plural": "Bolívares venezolanos"
+    },
+    "VND": {
+      "name": "Dong Vietnamita",
+      "name_plural": "Dongs vietnamitas"
+    },
+    "VUV": {
+      "name": "Vatu Vanuatuense",
+      "name_plural": "Vatus vanuatuenses"
+    },
+    "WST": {
+      "name": "Tala Samoana",
+      "name_plural": "Talas samoanas"
+    },
+    "XAF": {
+      "name": "Franco CFA BEAC",
+      "name_plural": "Francos CFA BEAC"
+    },
+    "XCD": {
+      "name": "Dólar del Caribe Oriental",
+      "name_plural": "Dólares del Caribe Oriental"
+    },
+    "XOF": {
+      "name": "Franco CFA BCEAO",
+      "name_plural": "Francos CFA BCEAO"
+    },
+    "XPF": {
+      "name": "Franco CFP",
+      "name_plural": "Francos CFP"
+    },
+    "YER": {
+      "name": "Rial Yemení",
+      "name_plural": "Riales yemeníes"
+    },
+    "ZAR": {
+      "name": "Rand Sudafricano",
+      "name_plural": "Rands sudafricanos"
+    },
+    "ZMW": {
+      "name": "Kwacha Zambiano",
+      "name_plural": "Kwacha zambianos"
+    },
+    "ZWL": {
+      "name": "Dólar Zimbabuense",
+      "name_plural": "Dólares zimbabuenses"
+    }
+  }
+}

--- a/public/locales/es-AR/expense_details.json
+++ b/public/locales/es-AR/expense_details.json
@@ -1,0 +1,76 @@
+{
+  "ui": {
+    "title": "Agregar gasto",
+    "title_mobile": "Agregar",
+    "add_expense": "Agregar gasto",
+    "add_expense_details": {
+      "add_new_expense": "Agregar nuevo gasto",
+      "description_placeholder": "Ingresá una descripción",
+      "amount_placeholder": "Ingresá la cantidad",
+      "split_type_section": {
+        "split_equally": "dividir por igual",
+        "split_unequally": "dividir de forma desigual",
+        "types": {
+          "equal": {
+            "title": "Igual",
+            "per_person": "por persona"
+          },
+          "percentage": {
+            "title": "Porcentaje",
+            "remaining": "Restante"
+          },
+          "exact": {
+            "title": "Exacto",
+            "remaining": "Restante"
+          },
+          "share": {
+            "title": "Cuota",
+            "total_shares": "Total de cuotas",
+            "shares": "Cuota(s)"
+          },
+          "adjustment": {
+            "title": "Ajuste",
+            "remaining_to_split_equally": "Restante para dividir por igual"
+          }
+        }
+      },
+      "pick_a_date": "Seleccionar una fecha",
+      "upload_file": {
+        "messages": {
+          "upload_success": "Archivo subido exitosamente"
+        },
+        "errors": {
+          "less_than": "El archivo debe ser menor de",
+          "upload_failed": "Error al subir el archivo",
+          "uploading_error": "Error al subir el archivo"
+        }
+      },
+      "sponsor_us": "Patrocinanos",
+      "user_input": {
+        "cannot_change_group": "No se puede cambiar el grupo mientras se edita",
+        "remove_group": "Presioná eliminar para quitar el grupo",
+        "add_more_friends": "Buscar amigos, grupos o agregar correo electrónico",
+        "search_friends": "Buscar amigos, grupos o agregar correo electrónico"
+      },
+      "select_user_or_group": {
+        "only_one_group_time": "Solo podés tener un grupo a la vez",
+        "warning": "Advertencia: No uses enviar invitación si el correo electrónico no es válido. Usá agregar a Split Pro en su lugar. Tu cuenta será bloqueada si se abusa de esta función",
+        "note": "Nota: el envío de invitaciones está deshabilitado por ahora debido al spam",
+        "send_invite": "Enviar invitación al usuario",
+        "add_to_split_pro": "Agregar a Split Pro"
+      }
+    },
+    "delete_expense_details": {
+      "title": "¿Estás absolutamente seguro?",
+      "text": "Esta acción no se puede deshacer. Esto eliminará permanentemente tu gasto."
+    },
+    "balance_list": {
+      "press_balance_info": "Presioná en el saldo individual para iniciar la liquidación",
+      "are_settled_up": "están liquidados",
+      "is_settled_up": "está liquidado"
+    },
+    "errors": {
+      "amount_required": "La cantidad es requerida"
+    }
+  }
+}

--- a/public/locales/es-AR/groups_details.json
+++ b/public/locales/es-AR/groups_details.json
@@ -1,0 +1,80 @@
+{
+  "ui": {
+    "title": "Saldos pendientes del grupo",
+    "no_members": {
+      "no_members": "Aún no hay miembros en el grupo.",
+      "add_members": "Agregar miembros",
+      "add_members_details": {
+        "title": "Agregar miembros",
+        "placeholder": "Ingresá nombre o correo electrónico",
+        "warning": "Advertencia: No uses enviar invitación si el correo electrónico no es válido. Usá agregar a Split Pro en su lugar. Tu cuenta será bloqueada si se abusa de esta función",
+        "note": "Nota: el envío de invitaciones está deshabilitado por ahora debido al spam",
+        "send_invite": "Enviar invitación al usuario",
+        "add_to_split_pro": "Agregar a Split Pro"
+      },
+      "invite_link": "Compartir enlace de invitación",
+      "copied": "Copiado"
+    },
+    "group_statistics": {
+      "title": "Estadísticas del grupo",
+      "total_expenses": "Gastos totales",
+      "first_expense": "Primer gasto"
+    },
+    "group_info": {
+      "title": "Información del grupo",
+      "members": "Miembros",
+      "group_created": "Grupo creado",
+      "actions": "Acciones",
+      "delete_group": "Eliminar grupo",
+      "delete_group_details": {
+        "title": "¿Estás absolutamente seguro?",
+        "can_delete": "Esta acción no se puede revertir",
+        "cant_delete": "No se puede eliminar el grupo hasta que todos liquiden el saldo"
+      },
+      "leave_group": "Abandonar grupo",
+      "leave_group_details": {
+        "title": "¿Estás absolutamente seguro?",
+        "can_leave": "Esta acción no se puede revertir",
+        "cant_leave": "No se puede abandonar el grupo hasta que tu saldo pendiente esté liquidado"
+      },
+      "remove_member_details": {
+        "title": "¿Estás absolutamente seguro?",
+        "can_remove": "Estás a punto de eliminar a este miembro del grupo",
+        "cant_remove": "No se puede eliminar al miembro hasta que su saldo pendiente esté liquidado"
+      },
+      "simplify_debts": "Simplificar deudas",
+      "recalculate_balances": "Recalcular saldos",
+      "recalculate_balances_details": {
+        "title": "¿Estás seguro?",
+        "description": "Si los saldos no coinciden con los gastos, podés recalculalos. Tené en cuenta que puede llevar algún tiempo si la cantidad de gastos es grande. Los saldos fuera del grupo no se verán afectados."
+      },
+      "archive_group": "Archivar grupo",
+      "archived": "Archivado",
+      "archive_group_details": {
+        "title": "¿Estás seguro de que querés archivar este grupo?",
+        "can_archive": "Este grupo será archivado y ocultado de tu lista principal de grupos. Podrás acceder a él más tarde si es necesario.",
+        "cant_archive": "No se puede archivar el grupo con saldos pendientes. Todos los saldos deben liquidarse primero."
+      }
+    },
+    "tabs": {
+      "expenses": "Gastos",
+      "balances": "Saldos"
+    },
+    "messages": {
+      "group_name_updated": "Nombre del grupo actualizado",
+      "balances_recalculated": "Saldos recalculados exitosamente",
+      "group_archived": "Grupo archivado exitosamente"
+    },
+    "errors": {
+      "group_name_update_failed": "Error al actualizar el nombre del grupo",
+      "setting_update_failed": "Error al actualizar la configuración"
+    },
+    "add_members": "Agregar miembros",
+    "copied": "Copiado"
+  },
+  "invite_message": {
+    "join_to": "Unite a",
+    "in_splitpro": "en Splitpro",
+    "text": "Unite al grupo y podrás agregar, gestionar gastos y seguir tus saldos"
+  }
+}

--- a/public/locales/es-AR/home.json
+++ b/public/locales/es-AR/home.json
@@ -1,0 +1,66 @@
+{
+  "meta": {
+    "title": "SplitPro: Dividí gastos con tus amigos gratis",
+    "description": "SplitPro: Dividí gastos con tus amigos gratis"
+  },
+  "nav": {
+    "app_name": "SplitPro",
+    "terms": "Términos",
+    "privacy": "Privacidad"
+  },
+  "hero": {
+    "title_part1": "Dividí gastos con tus amigos",
+    "title_highlight": "gratis",
+    "subtitle_part1": "Una alternativa de",
+    "subtitle_link": "código abierto",
+    "subtitle_part2": "a SplitWise",
+    "add_expense_button": "Agregar Gasto",
+    "star_github_button": "Danos una estrella en GitHub"
+  },
+  "features": {
+    "title": "Características",
+    "groups_and_friends": {
+      "title": "Grupos y Amigos",
+      "description": "Podés crear múltiples grupos o agregar saldo directamente. Todo se consolidará"
+    },
+    "multiple_currencies": {
+      "title": "Múltiples monedas",
+      "description": "¿Necesitás agregar un gasto con una moneda diferente para el mismo usuario? ¡No hay problema!"
+    },
+    "unequal_split": {
+      "title": "División Desigual",
+      "description": "Opciones avanzadas de división. Por cuotas, porcentaje o cantidades exactas."
+    },
+    "pwa_support": {
+      "title": "Soporte PWA",
+      "description": "¿Te encantan las aplicaciones móviles? Te tenemos cubierto. ¡Instalala como una PWA y ni siquiera lo notarás!"
+    },
+    "upload_receipts": {
+      "title": "Subir Recibos",
+      "description": "Subí recibos junto con el gasto"
+    },
+    "open_source": {
+      "title": "Código abierto",
+      "description": "Lo que hace difícil que se vuelva malvado. Fácil de autoalojar"
+    },
+    "import_splitwise": {
+      "title": "Importar desde Splitwise",
+      "description": "No tenés que migrar saldos manualmente. Podés importar usuarios y grupos desde Splitwise"
+    },
+    "push_notifications": {
+      "title": "Notificaciones push",
+      "description": "Nunca te pierdas notificaciones importantes. Recibí notificaciones cuando alguien agrega un gasto o liquida"
+    },
+    "debt_simplification": {
+      "title": "Simplificación de Deudas",
+      "description": "Simplifica automáticamente las deudas del grupo para reducir el número de transacciones necesarias entre amigos"
+    },
+    "i18": {
+      "title": "Internacionalización",
+      "description": "Disponible en múltiples idiomas para hacer que la división de gastos sea accesible en todo el mundo"
+    }
+  },
+  "footer": {
+    "built_by": "Construido por"
+  }
+}

--- a/public/locales/es-AR/signin.json
+++ b/public/locales/es-AR/signin.json
@@ -1,0 +1,22 @@
+{
+  "title": "SplitPro",
+  "auth": {
+    "continue_with": "Continuar con {{provider}}",
+    "email_placeholder": "Ingresá tu correo electrónico",
+    "send_magic_link": "Enviar enlace mágico",
+    "sending": "Enviando...",
+    "otp_sent": "Hemos enviado un correo electrónico con el OTP. Por favor, revisá tu bandeja de entrada y hacé clic en el enlace del correo electrónico para iniciar sesión.",
+    "trouble_logging_in": "¿Problemas para iniciar sesión? Contactá a"
+  },
+  "validation": {
+    "email_required": "El correo electrónico es obligatorio",
+    "email_invalid": "Correo electrónico inválido",
+    "otp_required": "El OTP es obligatorio",
+    "otp_invalid": "OTP inválido"
+  },
+  "errors": {
+    "signup_disabled": "El registro de nuevas cuentas está deshabilitado en esta instancia",
+    "signin_error": "Ocurrió un error al iniciar sesión: ",
+    "email_invalid": "El correo electrónico no es válido, por favor, intentá el proceso de inicio de sesión de nuevo."
+  }
+}

--- a/public/locales/es-MX/account_page.json
+++ b/public/locales/es-MX/account_page.json
@@ -1,0 +1,74 @@
+{
+  "ui": {
+    "title": "Cuenta",
+    "change_language": "Cambiar idioma",
+    "change_language_details": {
+      "title": "Seleccionar un idioma",
+      "messages": {
+        "language_changed": "Idioma cambiado exitosamente"
+      },
+      "errors": {
+        "language_change_failed": "Error al cambiar el idioma"
+      },
+      "placeholder": "Seleccionar un idioma"
+    },
+    "notifications": {
+      "enable_notification": "Habilitar notificaciones",
+      "disable_notification": "Deshabilitar notificaciones",
+      "messages": {
+        "notification_granted": "Ahora recibirás notificaciones"
+      },
+      "errors": {
+        "notification_not_supported": "Las notificaciones no son compatibles",
+        "subscribe_error": "No se puede suscribir a las notificaciones",
+        "unsubscribe_error": "Error al cancelar la suscripción a las notificaciones",
+        "request_error": "Error al solicitar notificaciones"
+      }
+    },
+    "download_app": "Descargar aplicación",
+    "download_app_details": {
+      "title": "Descargar aplicación",
+      "download_as_pwa": "Puedes descargar SplitPro como una PWA a tu pantalla de inicio.",
+      "using_ios": "Si usas iOS, revisa este",
+      "using_android": "Si usas Android, revisa este",
+      "video": "video"
+    },
+    "import_from_splitwise": "Importar desde Splitwise",
+    "import_from_splitwise_details": {
+      "choose_file": "Elegir archivo",
+      "no_file_chosen": "Ningún archivo seleccionado",
+      "note": "Nota: Actualmente solo soporta la importación de amigos y grupos. No importará transacciones. Estamos trabajando en ello.",
+      "follow_to_export_splitwise_data": "Sigue este enlace para exportar datos de Splitwise",
+      "export_splitwise_data_button": "Exportar datos de Splitwise",
+      "messages": {
+        "import_success": "Importación exitosa"
+      },
+      "errors": {
+        "import_failed": "Error al importar el archivo"
+      }
+    },
+    "download_splitpro_data": "Descargar datos de SplitPro",
+    "submit_feedback": "Enviar comentarios",
+    "submit_feedback_details": {
+      "title": "Enviar comentarios",
+      "placeholder": "Introduce tus comentarios"
+    },
+    "errors": {
+      "feedback_required": "Los comentarios son obligatorios",
+      "feedback_min_length": "Los comentarios deben tener al menos 10 caracteres"
+    },
+    "messages": {
+      "submit_success": "Comentarios enviados",
+      "submit_error": "Error al enviar los comentarios"
+    },
+    "write_review": "Escribir una reseña",
+    "star_on_github": "Danos una estrella en GitHub",
+    "support_us": "Patrocínanos",
+    "follow_on_x": "Síguenos en X",
+    "logout": "Cerrar sesión",
+    "edit_name": {
+      "title": "Editar nombre",
+      "placeholder": "Introduce el nombre"
+    }
+  }
+}

--- a/public/locales/es-MX/categories.json
+++ b/public/locales/es-MX/categories.json
@@ -1,0 +1,86 @@
+{
+  "title": "Categorías",
+  "categories_list": {
+    "entertainment": {
+      "name": "Entretenimiento",
+      "items": {
+        "games": "Juegos",
+        "movies": "Películas",
+        "music": "Música",
+        "sports": "Deportes",
+        "other": "Entretenimiento"
+      }
+    },
+    "food": {
+      "name": "Comida y Bebidas",
+      "items": {
+        "diningOut": "Comer fuera",
+        "groceries": "Comestibles",
+        "liquor": "Bebidas alcohólicas",
+        "other": "Comida y Bebidas"
+      }
+    },
+    "home": {
+      "name": "Hogar",
+      "items": {
+        "electronics": "Electrónica",
+        "furniture": "Muebles",
+        "supplies": "Suministros",
+        "maintenance": "Mantenimiento",
+        "mortgage": "Hipoteca",
+        "pets": "Mascotas",
+        "rent": "Alquiler",
+        "services": "Servicios",
+        "other": "Hogar"
+      }
+    },
+    "life": {
+      "name": "Vida",
+      "items": {
+        "childcare": "Cuidado de niños",
+        "clothing": "Ropa",
+        "education": "Educación",
+        "gifts": "Regalos",
+        "medical": "Médico",
+        "taxes": "Impuestos",
+        "other": "Vida",
+        "insurance": "Seguro"
+      }
+    },
+    "travel": {
+      "name": "Viajes",
+      "items": {
+        "bus": "Autobús",
+        "train": "Tren",
+        "car": "Coche",
+        "fuel": "Combustible",
+        "parking": "Estacionamiento",
+        "plane": "Avión",
+        "taxi": "Taxi",
+        "other": "Viajes",
+        "bicycle": "Bicicleta",
+        "hotel": "Hotel"
+      }
+    },
+    "utilities": {
+      "name": "Servicios",
+      "items": {
+        "cleaning": "Limpieza",
+        "electricity": "Electricidad",
+        "gas": "Gas",
+        "internet": "Internet",
+        "trash": "Basura",
+        "phone": "Teléfono",
+        "water": "Agua",
+        "other": "Servicios"
+      }
+    },
+    "general": {
+      "name": "General",
+      "items": {
+        "general": "General",
+        "other": "General"
+      }
+    }
+  }
+}

--- a/public/locales/es-MX/common.json
+++ b/public/locales/es-MX/common.json
@@ -1,0 +1,92 @@
+{
+  "meta": {
+    "title": "SplitPro: Divide gastos con tus amigos gratis",
+    "description": "Divide gastos con tus amigos gratis",
+    "application_name": "SplitPro"
+  },
+  "navigation": {
+    "app_name": "SplitPro",
+    "balances": "Saldos",
+    "groups": "Grupos",
+    "add_expense": "Añadir Gasto",
+    "add": "Añadir",
+    "activity": "Actividad",
+    "account": "Cuenta"
+  },
+  "ui": {
+    "actors": {
+      "you": "Tú",
+      "you_dativus": "A ti",
+      "you_accusativus": "A ti",
+      "friends": "Amigos",
+      "groups": "Grupos",
+      "members": "Miembros",
+      "owner": "Propietario",
+      "all": "Todos"
+    },
+    "actions": {
+      "cancel": "Cancelar",
+      "confirm": "Confirmar",
+      "submit": "Enviar",
+      "close": "Cerrar",
+      "back": "Volver",
+      "create": "Crear",
+      "save": "Guardar",
+      "leave": "Salir",
+      "invite": "Invitar",
+      "export": "Exportar",
+      "import": "Importar",
+      "add_expense": "Añadir gasto",
+      "edit_expense": "Editar gasto",
+      "settle_up": "Liquidar"
+    },
+    "expense": {
+      "you": {
+        "lent": "prestaste",
+        "owe": "debes",
+        "paid": "pagaste",
+        "pay": "pagar",
+        "received": "recibiste",
+        "deleted": "eliminaste"
+      },
+      "user": {
+        "lent": "prestó",
+        "owe": "debe",
+        "paid": "pagó",
+        "pay": "paga",
+        "received": "recibió",
+        "deleted": "eliminó"
+      },
+      "for": "para",
+      "paid_by": "Pagado por",
+      "received_by": "Recibido por",
+      "to": "a",
+      "from": "de"
+    },
+    "balance": "saldo",
+    "balances": "saldos",
+    "or": "o",
+    "and": "y",
+    "today": "Hoy",
+    "delete": "Eliminar",
+    "edited_by": "Editado por",
+    "deleted_by": "Eliminado por",
+    "added_by": "Añadido por",
+    "on": "el",
+    "not_involved": "No involucrado",
+    "no_activity": "Aún no hay actividades",
+    "settled_up": "Liquidado",
+    "settle_up_name": "Liquidar",
+    "settlement": "Liquidación",
+    "expense_details": "Detalles del gasto",
+    "select_currency": "Seleccionar moneda",
+    "outstanding_balances": "Saldos pendientes",
+    "share_text": "Echa un vistazo a SplitPro. Es una alternativa gratuita de código abierto a Splitwise"
+  },
+  "errors": {
+    "name_required": "El nombre es requerido",
+    "saving_expense": "Error al guardar el gasto",
+    "something_went_wrong": "Algo salió mal",
+    "valid_email": "Introduce un correo electrónico válido"
+  }
+}

--- a/public/locales/es-MX/currencies.json
+++ b/public/locales/es-MX/currencies.json
@@ -1,0 +1,559 @@
+{
+  "title": "Seleccionar moneda",
+  "placeholder": "Seleccionar moneda",
+  "no_currency_found": "No se encontró ninguna moneda.",
+  "currency_list": {
+    "CAD": {
+      "name": "Dólar Canadiense",
+      "name_plural": "Dólares canadienses"
+    },
+    "EUR": {
+      "name": "Euro",
+      "name_plural": "Euros"
+    },
+    "AED": {
+      "name": "Dirham de los Emiratos Árabes Unidos",
+      "name_plural": "Dirhams de los EAU"
+    },
+    "AFN": {
+      "name": "Afgani Afgano",
+      "name_plural": "Afganis afganos"
+    },
+    "ALL": {
+      "name": "Lek Albanés",
+      "name_plural": "Lekë albaneses"
+    },
+    "AMD": {
+      "name": "Dram Armenio",
+      "name_plural": "Drams armenios"
+    },
+    "ARS": {
+      "name": "Peso Argentino",
+      "name_plural": "Pesos argentinos"
+    },
+    "AUD": {
+      "name": "Dólar Australiano",
+      "name_plural": "Dólares australianos"
+    },
+    "AZN": {
+      "name": "Manat Azerbaiyano",
+      "name_plural": "Manats azerbaiyanos"
+    },
+    "BAM": {
+      "name": "Marco Convertible de Bosnia y Herzegovina",
+      "name_plural": "Marcos convertibles de Bosnia y Herzegovina"
+    },
+    "BDT": {
+      "name": "Taka Bangladesí",
+      "name_plural": "Takas bangladesíes"
+    },
+    "BGN": {
+      "name": "Lev Búlgaro",
+      "name_plural": "Leva búlgaros"
+    },
+    "BHD": {
+      "name": "Dinar Bahreiní",
+      "name_plural": "Dinares bahreiníes"
+    },
+    "BIF": {
+      "name": "Franco Burundés",
+      "name_plural": "Francos burundeses"
+    },
+    "BND": {
+      "name": "Dólar de Brunéi",
+      "name_plural": "Dólares de Brunéi"
+    },
+    "BOB": {
+      "name": "Boliviano Boliviano",
+      "name_plural": "Bolivianos bolivianos"
+    },
+    "BRL": {
+      "name": "Real Brasileño",
+      "name_plural": "Reales brasileños"
+    },
+    "BWP": {
+      "name": "Pula Botswanés",
+      "name_plural": "Pulas botswanéses"
+    },
+    "BYN": {
+      "name": "Rublo Bielorruso",
+      "name_plural": "Rublos bielorrusos"
+    },
+    "BZD": {
+      "name": "Dólar Beliceño",
+      "name_plural": "Dólares beliceños"
+    },
+    "CDF": {
+      "name": "Franco Congoleño",
+      "name_plural": "Francos congoleños"
+    },
+    "CHF": {
+      "name": "Franco Suizo",
+      "name_plural": "Francos suizos"
+    },
+    "CLP": {
+      "name": "Peso Chileno",
+      "name_plural": "Pesos chilenos"
+    },
+    "CNY": {
+      "name": "Yuan Chino",
+      "name_plural": "Yuanes chinos"
+    },
+    "COP": {
+      "name": "Peso Colombiano",
+      "name_plural": "Pesos colombianos"
+    },
+    "CRC": {
+      "name": "Colón Costarricense",
+      "name_plural": "Colones costarricenses"
+    },
+    "CVE": {
+      "name": "Escudo Caboverdiano",
+      "name_plural": "Escudos caboverdianos"
+    },
+    "CZK": {
+      "name": "Corona Checa",
+      "name_plural": "Coronas checas"
+    },
+    "DJF": {
+      "name": "Franco Yibutiano",
+      "name_plural": "Francos yibutianos"
+    },
+    "DKK": {
+      "name": "Corona Danesa",
+      "name_plural": "Coronas danesas"
+    },
+    "DOP": {
+      "name": "Peso Dominicano",
+      "name_plural": "Pesos dominicanos"
+    },
+    "DZD": {
+      "name": "Dinar Argelino",
+      "name_plural": "Dinares argelinos"
+    },
+    "EEK": {
+      "name": "Corona Estonia",
+      "name_plural": "Coronas estonias"
+    },
+    "EGP": {
+      "name": "Libra Egipcia",
+      "name_plural": "Libras egipcias"
+    },
+    "ERN": {
+      "name": "Nakfa Eritreo",
+      "name_plural": "Nakfas eritreos"
+    },
+    "ETB": {
+      "name": "Birr Etíope",
+      "name_plural": "Birrs etíopes"
+    },
+    "GBP": {
+      "name": "Libra Esterlina Británica",
+      "name_plural": "Libras esterlinas británicas"
+    },
+    "GEL": {
+      "name": "Lari Georgiano",
+      "name_plural": "Laris georgianos"
+    },
+    "GHS": {
+      "name": "Cedi Ghanés",
+      "name_plural": "Cedis ghaneses"
+    },
+    "GNF": {
+      "name": "Franco Guineano",
+      "name_plural": "Francos guineanos"
+    },
+    "GTQ": {
+      "name": "Quetzal Guatemalteco",
+      "name_plural": "Quetzales guatemaltecos"
+    },
+    "HKD": {
+      "name": "Dólar de Hong Kong",
+      "name_plural": "Dólares de Hong Kong"
+    },
+    "HNL": {
+      "name": "Lempira Hondureña",
+      "name_plural": "Lempiras hondureñas"
+    },
+    "HRK": {
+      "name": "Kuna Croata",
+      "name_plural": "Kunas croatas"
+    },
+    "HUF": {
+      "name": "Forint Húngaro",
+      "name_plural": "Forints húngaros"
+    },
+    "IDR": {
+      "name": "Rupia Indonesia",
+      "name_plural": "Rupias indonesias"
+    },
+    "ILS": {
+      "name": "Nuevo Shekel Israelí",
+      "name_plural": "Nuevos shekels israelíes"
+    },
+    "INR": {
+      "name": "Rupia India",
+      "name_plural": "Rupias indias"
+    },
+    "IQD": {
+      "name": "Dinar Iraquí",
+      "name_plural": "Dinares iraquíes"
+    },
+    "IRR": {
+      "name": "Rial Iraní",
+      "name_plural": "Riales iraníes"
+    },
+    "ISK": {
+      "name": "Corona Islandesa",
+      "name_plural": "Coronas islandesas"
+    },
+    "JMD": {
+      "name": "Dólar Jamaicano",
+      "name_plural": "Dólares jamaicanos"
+    },
+    "JOD": {
+      "name": "Dinar Jordano",
+      "name_plural": "Dinares jordanos"
+    },
+    "JPY": {
+      "name": "Yen Japonés",
+      "name_plural": "Yenes japoneses"
+    },
+    "KES": {
+      "name": "Chelín Keniano",
+      "name_plural": "Chelines kenianos"
+    },
+    "KHR": {
+      "name": "Riel Camboyano",
+      "name_plural": "Rieles camboyanos"
+    },
+    "KMF": {
+      "name": "Franco Comorense",
+      "name_plural": "Francos comorenses"
+    },
+    "KRW": {
+      "name": "Won Surcoreano",
+      "name_plural": "Wones surcoreanos"
+    },
+    "KWD": {
+      "name": "Dinar Kuwaití",
+      "name_plural": "Dinares kuwaitíes"
+    },
+    "KZT": {
+      "name": "Tenge Kazajo",
+      "name_plural": "Tenges kazajos"
+    },
+    "LAK": {
+      "name": "Kip Lao",
+      "name_plural": "Kips laosianos"
+    },
+    "LBP": {
+      "name": "Libra Libanesa",
+      "name_plural": "Libras libanesas"
+    },
+    "LKR": {
+      "name": "Rupia de Sri Lanka",
+      "name_plural": "Rupias de Sri Lanka"
+    },
+    "LRD": {
+      "name": "Dólar Liberiano",
+      "name_plural": "Dólares liberianos"
+    },
+    "LSL": {
+      "name": "Loti Lesotense",
+      "name_plural": "Lotis lesotenses"
+    },
+    "LYD": {
+      "name": "Dinar Libio",
+      "name_plural": "Dinares libios"
+    },
+    "MAD": {
+      "name": "Dirham Marroquí",
+      "name_plural": "Dirhams marroquíes"
+    },
+    "MDL": {
+      "name": "Leu Moldavo",
+      "name_plural": "Lei moldavos"
+    },
+    "MGA": {
+      "name": "Ariary Malgache",
+      "name_plural": "Ariaries malgaches"
+    },
+    "MKD": {
+      "name": "Denar Macedonio",
+      "name_plural": "Denari macedonios"
+    },
+    "MMK": {
+      "name": "Kyat Birmano",
+      "name_plural": "Kyats birmanos"
+    },
+    "MNT": {
+      "name": "Tugrik Mongol",
+      "name_plural": "Tugriks mongoles"
+    },
+    "MOP": {
+      "name": "Pataca de Macao",
+      "name_plural": "Patacas de Macao"
+    },
+    "MUR": {
+      "name": "Rupia Mauriciana",
+      "name_plural": "Rupias mauricianas"
+    },
+    "MVR": {
+      "name": "Rufiyaa Maldiva",
+      "name_plural": "Rufiyaas maldivas"
+    },
+    "MWK": {
+      "name": "Kwacha Malauí",
+      "name_plural": "Kwacha malauíes"
+    },
+    "MXN": {
+      "name": "Peso Mexicano",
+      "name_plural": "Pesos mexicanos"
+    },
+    "MYR": {
+      "name": "Ringgit Malayo",
+      "name_plural": "Ringgits malayos"
+    },
+    "MZN": {
+      "name": "Metical Mozambiqueño",
+      "name_plural": "Meticales mozambiqueños"
+    },
+    "NAD": {
+      "name": "Dólar Namibio",
+      "name_plural": "Dólares namibios"
+    },
+    "NGN": {
+      "name": "Naira Nigeriana",
+      "name_plural": "Nairas nigerianas"
+    },
+    "NIO": {
+      "name": "Córdoba Nicaragüense",
+      "name_plural": "Córdobas nicaragüenses"
+    },
+    "NOK": {
+      "name": "Corona Noruega",
+      "name_plural": "Coronas noruegas"
+    },
+    "NPR": {
+      "name": "Rupia Nepalí",
+      "name_plural": "Rupias nepalíes"
+    },
+    "NZD": {
+      "name": "Dólar Neozelandés",
+      "name_plural": "Dólares neozelandeses"
+    },
+    "OMR": {
+      "name": "Rial Omaní",
+      "name_plural": "Riales omaníes"
+    },
+    "PAB": {
+      "name": "Balboa Panameño",
+      "name_plural": "Balboas panameños"
+    },
+    "PEN": {
+      "name": "Nuevo Sol Peruano",
+      "name_plural": "Nuevos soles peruanos"
+    },
+    "PGK": {
+      "name": "Kina de Papúa Nueva Guinea",
+      "name_plural": "Kinas de Papúa Nueva Guinea"
+    },
+    "PHP": {
+      "name": "Peso Filipino",
+      "name_plural": "Pesos filipinos"
+    },
+    "PKR": {
+      "name": "Rupia Pakistaní",
+      "name_plural": "Rupias pakistaníes"
+    },
+    "PLN": {
+      "name": "Zloty Polaco",
+      "name_plural": "Zlotys polacos"
+    },
+    "PYG": {
+      "name": "Guaraní Paraguayo",
+      "name_plural": "Guaraníes paraguayos"
+    },
+    "QAR": {
+      "name": "Rial Qatarí",
+      "name_plural": "Riales qataríes"
+    },
+    "RON": {
+      "name": "Leu Rumano",
+      "name_plural": "Lei rumanos"
+    },
+    "RSD": {
+      "name": "Dinar Serbio",
+      "name_plural": "Dinares serbios"
+    },
+    "RUB": {
+      "name": "Rublo Ruso",
+      "name_plural": "Rublos rusos"
+    },
+    "RWF": {
+      "name": "Franco Ruandés",
+      "name_plural": "Francos ruandeses"
+    },
+    "SAR": {
+      "name": "Riyal Saudí",
+      "name_plural": "Riyales saudíes"
+    },
+    "SBD": {
+      "name": "Dólar de las Islas Salomón",
+      "name_plural": "Dólares de las Islas Salomón"
+    },
+    "SCR": {
+      "name": "Rupia Seychellense",
+      "name_plural": "Rupias seychellenses"
+    },
+    "SDG": {
+      "name": "Libra Sudanesa",
+      "name_plural": "Libras sudanesas"
+    },
+    "SEK": {
+      "name": "Corona Sueca",
+      "name_plural": "Coronas suecas"
+    },
+    "SGD": {
+      "name": "Dólar de Singapur",
+      "name_plural": "Dólares de Singapur"
+    },
+    "SHP": {
+      "name": "Libra de Santa Elena",
+      "name_plural": "Libras de Santa Elena"
+    },
+    "SLL": {
+      "name": "Leone de Sierra Leona",
+      "name_plural": "Leones de Sierra Leona"
+    },
+    "SOS": {
+      "name": "Chelín Somalí",
+      "name_plural": "Chelines somalíes"
+    },
+    "SRD": {
+      "name": "Dólar Surinamés",
+      "name_plural": "Dólares surinameses"
+    },
+    "SSP": {
+      "name": "Libra Sudanesa del Sur",
+      "name_plural": "Libras sudanesas del sur"
+    },
+    "STD": {
+      "name": "Dobra de Santo Tomé y Príncipe",
+      "name_plural": "Dobras de Santo Tomé y Príncipe"
+    },
+    "SYP": {
+      "name": "Libra Siria",
+      "name_plural": "Libras sirias"
+    },
+    "SZL": {
+      "name": "Lilangeni Suazi",
+      "name_plural": "Emalangeni suazis"
+    },
+    "THB": {
+      "name": "Baht Tailandés",
+      "name_plural": "Baht tailandeses"
+    },
+    "TJS": {
+      "name": "Somoni Tayiko",
+      "name_plural": "Somonis tayikos"
+    },
+    "TMT": {
+      "name": "Manat Turcomano",
+      "name_plural": "Manats turcomanos"
+    },
+    "TND": {
+      "name": "Dinar Tunecino",
+      "name_plural": "Dinares tunecinos"
+    },
+    "TOP": {
+      "name": "Paʻanga Tongano",
+      "name_plural": "Paʻangas tonganos"
+    },
+    "TRY": {
+      "name": "Lira Turca",
+      "name_plural": "Liras turcas"
+    },
+    "TTD": {
+      "name": "Dólar de Trinidad y Tobago",
+      "name_plural": "Dólares de Trinidad y Tobago"
+    },
+    "TWD": {
+      "name": "Nuevo Dólar Taiwanés",
+      "name_plural": "Nuevos dólares taiwaneses"
+    },
+    "TZS": {
+      "name": "Chelín Tanzano",
+      "name_plural": "Chelines tanzanos"
+    },
+    "UAH": {
+      "name": "Grivna Ucraniana",
+      "name_plural": "Grivnas ucranianas"
+    },
+    "UGX": {
+      "name": "Chelín Ugandés",
+      "name_plural": "Chelines ugandeses"
+    },
+    "USD": {
+      "name": "Dólar Estadounidense",
+      "name_plural": "Dólares estadounidenses"
+    },
+    "UYU": {
+      "name": "Peso Uruguayo",
+      "name_plural": "Pesos uruguayos"
+    },
+    "UZS": {
+      "name": "Som Uzbeko",
+      "name_plural": "Soms uzbekos"
+    },
+    "VEF": {
+      "name": "Bolívar Venezolano",
+      "name_plural": "Bolívares venezolanos"
+    },
+    "VND": {
+      "name": "Dong Vietnamita",
+      "name_plural": "Dongs vietnamitas"
+    },
+    "VUV": {
+      "name": "Vatu Vanuatuense",
+      "name_plural": "Vatus vanuatuenses"
+    },
+    "WST": {
+      "name": "Tala Samoana",
+      "name_plural": "Talas samoanas"
+    },
+    "XAF": {
+      "name": "Franco CFA BEAC",
+      "name_plural": "Francos CFA BEAC"
+    },
+    "XCD": {
+      "name": "Dólar del Caribe Oriental",
+      "name_plural": "Dólares del Caribe Oriental"
+    },
+    "XOF": {
+      "name": "Franco CFA BCEAO",
+      "name_plural": "Francos CFA BCEAO"
+    },
+    "XPF": {
+      "name": "Franco CFP",
+      "name_plural": "Francos CFP"
+    },
+    "YER": {
+      "name": "Rial Yemení",
+      "name_plural": "Riales yemeníes"
+    },
+    "ZAR": {
+      "name": "Rand Sudafricano",
+      "name_plural": "Rands sudafricanos"
+    },
+    "ZMW": {
+      "name": "Kwacha Zambiano",
+      "name_plural": "Kwacha zambianos"
+    },
+    "ZWL": {
+      "name": "Dólar Zimbabuense",
+      "name_plural": "Dólares zimbabuenses"
+    }
+  }
+}

--- a/public/locales/es-MX/expense_details.json
+++ b/public/locales/es-MX/expense_details.json
@@ -1,0 +1,76 @@
+{
+  "ui": {
+    "title": "Añadir gasto",
+    "title_mobile": "Añadir",
+    "add_expense": "Añadir gasto",
+    "add_expense_details": {
+      "add_new_expense": "Añadir nuevo gasto",
+      "description_placeholder": "Introduce una descripción",
+      "amount_placeholder": "Introduce la cantidad",
+      "split_type_section": {
+        "split_equally": "dividir por igual",
+        "split_unequally": "dividir de forma desigual",
+        "types": {
+          "equal": {
+            "title": "Igual",
+            "per_person": "por persona"
+          },
+          "percentage": {
+            "title": "Porcentaje",
+            "remaining": "Restante"
+          },
+          "exact": {
+            "title": "Exacto",
+            "remaining": "Restante"
+          },
+          "share": {
+            "title": "Cuota",
+            "total_shares": "Total de cuotas",
+            "shares": "Cuota(s)"
+          },
+          "adjustment": {
+            "title": "Ajuste",
+            "remaining_to_split_equally": "Restante para dividir por igual"
+          }
+        }
+      },
+      "pick_a_date": "Seleccionar una fecha",
+      "upload_file": {
+        "messages": {
+          "upload_success": "Archivo subido exitosamente"
+        },
+        "errors": {
+          "less_than": "El archivo debe ser menor de",
+          "upload_failed": "Error al subir el archivo",
+          "uploading_error": "Error al subir el archivo"
+        }
+      },
+      "sponsor_us": "Patrocínanos",
+      "user_input": {
+        "cannot_change_group": "No se puede cambiar el grupo mientras se edita",
+        "remove_group": "Pulsa eliminar para quitar el grupo",
+        "add_more_friends": "Buscar amigos, grupos o añadir correo electrónico",
+        "search_friends": "Buscar amigos, grupos o añadir correo electrónico"
+      },
+      "select_user_or_group": {
+        "only_one_group_time": "Solo puedes tener un grupo a la vez",
+        "warning": "Advertencia: No uses enviar invitación si el correo electrónico no es válido. Usa añadir a Split Pro en su lugar. Tu cuenta será bloqueada si se abusa de esta función",
+        "note": "Nota: el envío de invitaciones está deshabilitado por ahora debido al spam",
+        "send_invite": "Enviar invitación al usuario",
+        "add_to_split_pro": "Añadir a Split Pro"
+      }
+    },
+    "delete_expense_details": {
+      "title": "¿Estás absolutamente seguro?",
+      "text": "Esta acción no se puede deshacer. Esto eliminará permanentemente tu gasto."
+    },
+    "balance_list": {
+      "press_balance_info": "Pulsa en el saldo individual para iniciar la liquidación",
+      "are_settled_up": "están liquidados",
+      "is_settled_up": "está liquidado"
+    },
+    "errors": {
+      "amount_required": "La cantidad es requerida"
+    }
+  }
+}

--- a/public/locales/es-MX/groups_details.json
+++ b/public/locales/es-MX/groups_details.json
@@ -1,0 +1,84 @@
+{
+  "ui": {
+    "title": "Saldos pendientes del grupo",
+    "no_members": {
+      "no_members": "Aún no hay miembros en el grupo.",
+      "add_members": "Añadir miembros",
+      "add_members_details": {
+        "title": "Añadir miembros",
+        "placeholder": "Introduce nombre o correo electrónico",
+        "warning": "Advertencia: No uses enviar invitación si el correo electrónico no es válido. Usa añadir a Split Pro en su lugar. Tu cuenta será bloqueada si se abusa de esta función",
+        "note": "Nota: el envío de invitaciones está deshabilitado por ahora debido al spam",
+        "send_invite": "Enviar invitación al usuario",
+        "add_to_split_pro": "Añadir a Split Pro"
+      },
+      "invite_link": "Compartir enlace de invitación",
+      "copied": "Copiado"
+    },
+    "group_statistics": {
+      "title": "Estadísticas del grupo",
+      "total_expenses": "Gastos totales",
+      "first_expense": "Primer gasto"
+    },
+    "group_info": {
+      "title": "Información del grupo",
+      "members": "Miembros",
+      "group_created": "Grupo creado",
+      "actions": "Acciones",
+      "delete_group": "Eliminar grupo",
+      "delete_group_details": {
+        "title": "¿Estás absolutamente seguro?",
+        "can_delete": "Esta acción no se puede revertir",
+        "cant_delete": "No se puede eliminar el grupo hasta que todos liquiden el saldo"
+      },
+      "leave_group": "Abandonar grupo",
+      "leave_group_details": {
+        "title": "¿Estás absolutamente seguro?",
+        "can_leave": "Esta acción no se puede revertir",
+        "cant_leave": "No se puede abandonar el grupo hasta que tu saldo pendiente esté liquidado"
+      },
+      "remove_member_details": {
+        "title": "¿Estás absolutamente seguro?",
+        "can_remove": "Estás a punto de eliminar a este miembro del grupo",
+        "cant_remove": "No se puede eliminar al miembro hasta que su saldo pendiente esté liquidado"
+      },
+      "simplify_debts": "Simplificar deudas",
+      "recalculate_balances": "Recalcular saldos",
+      "recalculate_balances_details": {
+        "title": "¿Estás seguro?",
+        "description": "Si los saldos no coinciden con los gastos, puedes recalculalos. Ten en cuenta que puede llevar algún tiempo si la cantidad de gastos es grande. Los saldos fuera del grupo no se verán afectados."
+      },
+      "archive_group": "Archivar grupo",
+      "archived": "Archivado",
+      "archive_group_details": {
+        "title": "¿Estás seguro de que quieres archivar este grupo?",
+        "can_archive": "Este grupo será archivado y ocultado de tu lista principal de grupos. Podrás acceder a él más tarde si es necesario.",
+        "cant_archive": "No se puede archivar el grupo con saldos pendientes. Todos los saldos deben liquidarse primero."
+      }
+    },
+    "tabs": {
+      "expenses": "Gastos",
+      "balances": "Saldos"
+    },
+    "messages": {
+      "group_name_updated": "Nombre del grupo actualizado",
+      "balances_recalculated": "Saldos recalculados exitosamente",
+      "group_archived": "Grupo archivado exitosamente"
+    },
+    "errors": {
+      "group_name_update_failed": "Error al actualizar el nombre del grupo",
+      "setting_update_failed": "Error al actualizar la configuración"
+    },
+    "add_members": "Añadir miembros",
+    "copied": "Copiado",
+    "create_group": {
+      "title": "Crear un grupo",
+      "group_name_placeholder": "Nombre del grupo"
+    }
+  },
+  "invite_message": {
+    "join_to": "Únete a",
+    "in_splitpro": "en Splitpro",
+    "text": "Únete al grupo y podrás añadir, gestionar gastos y seguir tus saldos"
+  }
+}

--- a/public/locales/es-MX/home.json
+++ b/public/locales/es-MX/home.json
@@ -1,0 +1,66 @@
+{
+  "meta": {
+    "title": "SplitPro: Divide gastos con tus amigos gratis",
+    "description": "SplitPro: Divide gastos con tus amigos gratis"
+  },
+  "nav": {
+    "app_name": "SplitPro",
+    "terms": "Términos",
+    "privacy": "Privacidad"
+  },
+  "hero": {
+    "title_part1": "Divide gastos con tus amigos",
+    "title_highlight": "gratis",
+    "subtitle_part1": "Una alternativa de",
+    "subtitle_link": "código abierto",
+    "subtitle_part2": "a SplitWise",
+    "add_expense_button": "Añadir Gasto",
+    "star_github_button": "Danos una estrella en GitHub"
+  },
+  "features": {
+    "title": "Características",
+    "groups_and_friends": {
+      "title": "Grupos y Amigos",
+      "description": "Puedes crear múltiples grupos o añadir saldo directamente. Todo se consolidará"
+    },
+    "multiple_currencies": {
+      "title": "Múltiples monedas",
+      "description": "¿Necesitas añadir un gasto con una moneda diferente para el mismo usuario? ¡No hay problema!"
+    },
+    "unequal_split": {
+      "title": "División Desigual",
+      "description": "Opciones avanzadas de división. Por cuotas, porcentaje o cantidades exactas."
+    },
+    "pwa_support": {
+      "title": "Soporte PWA",
+      "description": "¿Te encantan las aplicaciones móviles? Te tenemos cubierto. ¡Instálala como una PWA y ni siquiera lo notarás!"
+    },
+    "upload_receipts": {
+      "title": "Subir Recibos",
+      "description": "Sube recibos junto con el gasto"
+    },
+    "open_source": {
+      "title": "Código abierto",
+      "description": "Lo que hace difícil que se vuelva malvado. Fácil de autoalojar"
+    },
+    "import_splitwise": {
+      "title": "Importar desde Splitwise",
+      "description": "No tienes que migrar saldos manualmente. Puedes importar usuarios y grupos desde Splitwise"
+    },
+    "push_notifications": {
+      "title": "Notificaciones push",
+      "description": "Nunca te pierdas notificaciones importantes. Recibe notificaciones cuando alguien añade un gasto o liquida"
+    },
+    "debt_simplification": {
+      "title": "Simplificación de Deudas",
+      "description": "Simplifica automáticamente las deudas del grupo para reducir el número de transacciones necesarias entre amigos"
+    },
+    "i18": {
+      "title": "Internacionalización",
+      "description": "Disponible en múltiples idiomas para hacer que la división de gastos sea accesible en todo el mundo"
+    }
+  },
+  "footer": {
+    "built_by": "Construido por"
+  }
+}

--- a/public/locales/es-MX/signin.json
+++ b/public/locales/es-MX/signin.json
@@ -1,0 +1,22 @@
+{
+  "title": "SplitPro",
+  "auth": {
+    "continue_with": "Continuar con {{provider}}",
+    "email_placeholder": "Introduce tu correo electrónico",
+    "send_magic_link": "Enviar enlace mágico",
+    "sending": "Enviando...",
+    "otp_sent": "Hemos enviado un correo electrónico con el OTP. Por favor, revisa tu bandeja de entrada y haz clic en el enlace del correo electrónico para iniciar sesión.",
+    "trouble_logging_in": "¿Problemas para iniciar sesión? Contacta a"
+  },
+  "validation": {
+    "email_required": "El correo electrónico es obligatorio",
+    "email_invalid": "Correo electrónico inválido",
+    "otp_required": "El OTP es obligatorio",
+    "otp_invalid": "OTP inválido"
+  },
+  "errors": {
+    "signup_disabled": "El registro de nuevas cuentas está deshabilitado en esta instancia",
+    "signin_error": "Ocurrió un error al iniciar sesión: ",
+    "email_invalid": "El correo electrónico no es válido, por favor, intenta el proceso de inicio de sesión de nuevo."
+  }
+}

--- a/src/utils/i18n/client.ts
+++ b/src/utils/i18n/client.ts
@@ -10,4 +10,6 @@ export const getSupportedLanguages = (): SupportedLanguage[] => [
   { code: 'pl', name: 'Polski' },
   { code: 'pt', name: 'Portuguese' },
   { code: 'sv', name: 'Svenska' },
+  { code: 'es-MX', name: 'Spanish (Mexico)' },
+  { code: 'es-AR', name: 'Spanish (Argentina)' },
 ];


### PR DESCRIPTION
The following changes have been implemented:

**New translations in spanish**: **Spanish-Mexico** and **Spanish-Argentina**

- **New Locale Directories:** Created `public/locales/es-MX` and `public/locales/es-AR` directories.
- **Translated Locale Files:** All `.json` files (common, account_page, categories, currencies, expense_details, groups_details, home, signin) have been translated for both `es-MX` and `es-AR`.
- **Configuration Updates:**
    - `next-i18next.config.js`: Updated the `locales` array to include `es-MX` and `es-AR`.
    - `src/utils/i18n/client.ts`: Added `es-MX` and `es-AR` to the `getSupportedLanguages` array, with display names "Spanish (Mexico)" and "Spanish (Argentina)" respectively.