### PR TITLE
Fix service worker precache failure

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,8 @@ const nextConfigFunction = async (phase) => {
     const withPWA = (await import('@ducanh2912/next-pwa')).default({
       dest: 'public',
       disable: 'development' === process.env.NODE_ENV,
+      // @ts-expect-error buildExcludes is supported at runtime even if missing in types
+      buildExcludes: [/_next\/dynamic-css-manifest\.json$/],
     });
     return withPWA(nextConfig);
   }


### PR DESCRIPTION
**Description**

Exclude /_next/dynamic-css-manifest.json from the next-pwa precache list so the service worker can finish installing in production.
**Without this exclusion Workbox aborts install with bad-precaching-response, leaving push notifications broken.**

**# Demo**
N/A – config-only change.

# Checklist

-  I have read CONTRIBUTING.md in its entirety
-  I have performed a self-review of my own code
-  I have added unit tests to cover my changes
-  The last commit successfully passed pre-commit checks
-  Any AI code was thoroughly reviewed by me
