### PR TITLE
Add locale-aware date formatting for UI dates

### DIFF
--- a/src/utils/i18n/client.ts
+++ b/src/utils/i18n/client.ts
@@ -1,20 +1,17 @@
-import { type Locale, de, enUS, es, fr, it, pl, pt, ptBR, sv } from 'date-fns/locale';
-
 export interface SupportedLanguage {
   code: string;
   name: string;
-  dateLocale: Locale;
 }
 
 export const getSupportedLanguages = (): SupportedLanguage[] => [
-  { code: 'en', name: 'English', dateLocale: enUS },
-  { code: 'de', name: 'Deutsch', dateLocale: de },
-  { code: 'fr', name: 'Français', dateLocale: fr },
-  { code: 'it', name: 'Italiano', dateLocale: it },
-  { code: 'pl', name: 'Polski', dateLocale: pl },
-  { code: 'pt-PT', name: 'Portuguese (Portugal)', dateLocale: pt },
-  { code: 'pt-BR', name: 'Portuguese (Brazil)', dateLocale: ptBR },
-  { code: 'sv', name: 'Svenska', dateLocale: sv },
-  { code: 'es-MX', name: 'Spanish (Mexico)', dateLocale: es },
-  { code: 'es-AR', name: 'Spanish (Argentina)', dateLocale: es },
+  { code: 'en', name: 'English' },
+  { code: 'de', name: 'Deutsch' },
+  { code: 'fr', name: 'Français' },
+  { code: 'it', name: 'Italiano' },
+  { code: 'pl', name: 'Polski' },
+  { code: 'pt-PT', name: 'Portuguese (Portugal)' },
+  { code: 'pt-BR', name: 'Portuguese (Brazil)' },
+  { code: 'sv', name: 'Svenska' },
+  { code: 'es-MX', name: 'Spanish (Mexico)' },
+  { code: 'es-AR', name: 'Spanish (Argentina)' },
 ];

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,9 +1,8 @@
 import { SplitType, type User } from '@prisma/client';
-import { format, isToday } from 'date-fns';
+import { isToday } from 'date-fns';
 import { type TFunction } from 'next-i18next';
 import { type CurrencyCode } from '~/lib/currency';
 import { type AddExpenseState, type Participant } from '~/store/addStore';
-import { getSupportedLanguages } from './i18n/client';
 
 export type ParametersExceptTranslation<F> = F extends (t: TFunction, ...rest: infer R) => any
   ? R
@@ -38,10 +37,12 @@ export const toUIDate = (
     }).format(date);
   }
 
-  return format(date, 'MMM dd', {
-    locale: getSupportedLanguages().find((lang) => lang.code === todayTranslation.usedLng)
-      ?.dateLocale,
-  });
+  const day = new Intl.DateTimeFormat(todayTranslation.usedLng, { day: '2-digit' }).format(date);
+  const monthName = new Intl.DateTimeFormat(todayTranslation.usedLng, { month: 'short' })
+    .format(date)
+    .replace('.', '');
+
+  return `${monthName} ${day}`;
 };
 
 export function generateSplitDescription(


### PR DESCRIPTION
# Description
Adds locale-aware dates, fixes #470.

# Demo
<table><tr><td>
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/d54a3c0c-e1cc-4083-8b26-77abfb916db4" />
</td><td>
<img width="350" alt="image" src="https://github.com/user-attachments/assets/470f2ebc-16c0-4f7b-be1e-82315735405b" />
</td></tr></table>

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me
