### PR TITLE
Fix 478 always handle both decimal keys

### DIFF
--- a/src/components/ui/currency-input.tsx
+++ b/src/components/ui/currency-input.tsx
@@ -40,7 +40,7 @@ const CurrencyInput: React.FC<
       }}
       onChange={(e) => {
         const rawValue = e.target.value;
-        const strValue = sanitizeInput(rawValue, allowNegative);
+        const strValue = sanitizeInput(rawValue, allowNegative, true);
         const bigIntValue = toSafeBigInt(strValue, allowNegative);
         onValueChange({ strValue, bigIntValue });
       }}

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -79,7 +79,7 @@ export const getCurrencyHelpers = ({
   };
 
   /* Sanitize input by allowing only digits, negative sign, and one decimal separator */
-  const sanitizeInput = (input: string, signed = false) => {
+  const sanitizeInput = (input: string, signed = false, alternativeDecimal = false) => {
     let cleaned = '';
     let hasDecimalSeparator = false;
     let hasNegativeSign = false;
@@ -92,6 +92,7 @@ export const getCurrencyHelpers = ({
         return;
       }
       if (
+        alternativeDecimal &&
         letter === alternativeDecimalSeparator &&
         !hasDecimalSeparator &&
         !input.includes(decimalSeparator)


### PR DESCRIPTION
Closes #478 

A user friendly solution that accepts both `.` and `,` as decimal separators if the primary separator is not present.