### PR TITLE
Fixes the amount input not updating after a currency conversion

### DIFF
--- a/src/components/AddExpense/AddExpensePage.tsx
+++ b/src/components/AddExpense/AddExpensePage.tsx
@@ -54,7 +54,7 @@ export const AddOrEditExpensePage: React.FC<{
   const cronExpression = useAddExpenseStore((s) => s.cronExpression);
   const multipleTransactions = useAddExpenseStore((s) => s.multipleTransactions);
 
-  const { t, displayName, generateSplitDescription } = useTranslationWithUtils();
+  const { t, displayName, generateSplitDescription, getCurrencyHelpersCached } = useTranslationWithUtils();
 
   const {
     setCurrency,
@@ -236,9 +236,10 @@ export const AddOrEditExpensePage: React.FC<{
           to: currency,
         });
       setAmount(targetAmount);
+      setAmountStr(getCurrencyHelpersCached(currency).toUIString(targetAmount, false, true));
       previousCurrencyRef.current = null;
     },
-    [setAmount, currency],
+    [setAmount, setAmountStr, currency, getCurrencyHelpersCached],
   );
 
   const currencyConversionComponent = React.useMemo(() => {


### PR DESCRIPTION
After using the currency conversion dialog (e.g. USD → EUR), setAmount() correctly updated the internal BigInt value, but amountStr (the string displayed in the input field) was never updated. The user would see the old amount in the input even though the underlying value was already converted.

If there is a easier/cleaner fix, you can close the PR without comment.
Also, I haven't taken the time to setup a dev env (sorry, I cannot invest it at the moment, so it is very much docker build on my prod instance type of environment). As such, no linting/formatting is applied.