### PR TITLE
Support GitLab as a generic OIDC provider

### DIFF
--- a/src/pages/auth/signin.tsx
+++ b/src/pages/auth/signin.tsx
@@ -4,6 +4,7 @@ import {
   SiAuthelia,
   SiAuthentik,
   SiGithub,
+  SiGitlab,
   SiGoogle,
   SiKeycloak,
 } from '@icons-pack/react-simple-icons';
@@ -38,6 +39,7 @@ const providerSvgs = {
   authelia: <SiAuthelia />,
   auth0: <SiAuth0 />,
   keycloak: <SiKeycloak />,
+  gitlab: <SiGitlab />,
 };
 
 const providerTypeGuard = (providerId: string): providerId is keyof typeof providerSvgs =>


### PR DESCRIPTION
# Description
Adds a workaround for gitlab as an oicd provider. Gitlab returns a non-standard `created_at` field during authentication that needs to be discarded before passing it on to the database schema, just like what already happens for keycloak. Also adds a gitlab icon for the provider id "gitlab".

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [ ] The last commit successfully passed pre-commit checks (It should be fine, but I skipped the pre-commit checks because they weirdly capitalized an unrelated multi-line comment later in the file)
- [x] Any AI code was thoroughly reviewed by me
