### PR TITLE
Display archived groups when no active groups exist

### DIFF
--- a/src/pages/groups.tsx
+++ b/src/pages/groups.tsx
@@ -45,7 +45,7 @@ const BalancePage: NextPageWithUser = () => {
       <MainLayout title={t('navigation.groups')} actions={actions} loading={groupQuery.isPending}>
         <div className="mt-7 flex flex-col gap-8 pb-36">
           {0 === groupQuery.data?.length ? (
-            <div className="mt-[30vh] flex flex-col items-center justify-center gap-20">
+            <div className="mt-[30vh] mb-16 flex flex-col items-center justify-center gap-20">
               <CreateGroup>
                 <Button>
                   <PlusIcon className="mr-2 h-4 w-4" />
@@ -64,25 +64,24 @@ const BalancePage: NextPageWithUser = () => {
                   balances={transformBalances(g.balances)}
                 />
               ))}
-
-              {/* Archived Groups Accordion */}
-              {archivedGroupQuery.data && archivedGroupQuery.data.length > 0 && (
-                <Accordion type="single" collapsible className="w-full">
-                  <AccordionItem value="archived-groups">
-                    <AccordionTrigger className="text-left text-sm text-gray-400">
-                      {t('group_details.group_info.archived')} ({archivedGroupQuery.data.length})
-                    </AccordionTrigger>
-                    <AccordionContent>
-                      <div className="mt-7 flex flex-col gap-8">
-                        {archivedGroupQuery.data.map((g) => (
-                          <BalanceEntry key={g.id} id={g.id} entity={g} />
-                        ))}
-                      </div>
-                    </AccordionContent>
-                  </AccordionItem>
-                </Accordion>
-              )}
             </>
+          )}
+          {/* Archived Groups Accordion */}
+          {archivedGroupQuery.data && archivedGroupQuery.data.length > 0 && (
+            <Accordion type="single" collapsible className="w-full">
+              <AccordionItem value="archived-groups">
+                <AccordionTrigger className="text-left text-sm text-gray-400">
+                  {t('group_details.group_info.archived')} ({archivedGroupQuery.data.length})
+                </AccordionTrigger>
+                <AccordionContent>
+                  <div className="mt-7 flex flex-col gap-8">
+                    {archivedGroupQuery.data.map((g) => (
+                      <BalanceEntry key={g.id} id={g.id} entity={g} />
+                    ))}
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
           )}
         </div>
       </MainLayout>


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change -->
<!-- Any details that you think are important to review this PR? -->
<!-- What issue/PR is it related to? Add appropriate closing keywords like Closing #123 -->

The list of archived groups isn't displayed on the groups page when there are no active groups.

🤖 I’ve added tests to verify that expected elements render correctly in the DOM. I used AI to generate the initial boilerplate, as I’m not yet familiar with writing tests in the Next.js framework. There’s also a question of whether Cypress would be preferable to introduce end-to-end tests for a broader regression prevention.

# Demo
<!-- Add a screenshot or a video demonstration when possible -->

| Before | After |
|--------|--------|
| <img width="780" height="1688" alt="Screenshot 2026-02-13 at 08-03-30 Groups" src="https://github.com/user-attachments/assets/4e4d3616-259a-4809-9328-95f6b775c5f5" /> | <img width="780" height="1688" alt="Screenshot 2026-02-16 at 07-25-54 Groups" src="https://github.com/user-attachments/assets/90653008-1dcc-48c3-a4c3-fb20a79b7817" /> |

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [x] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me
