### PR TITLE
Fix docker compose postgres volume path

### DIFF
--- a/docker/dev/compose.yml
+++ b/docker/dev/compose.yml
@@ -2,7 +2,7 @@ name: split-pro-dev
 
 services:
   postgres:
-    image: ossapps/postgres
+    image: ossapps/postgres:17.7-trixie
     container_name: ${POSTGRES_CONTAINER_NAME:-splitpro-db}
     restart: always
     environment:
@@ -11,7 +11,7 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-splitpro}
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
     volumes:
-      - database:/var/lib/postgresql
+      - database:/var/lib/postgresql/data
     command: >
       postgres
       -c shared_preload_libraries=pg_cron

--- a/docker/prod/compose.yml
+++ b/docker/prod/compose.yml
@@ -24,7 +24,7 @@ services:
     #   - "5432:5432"
     env_file: .env
     volumes:
-      - database:/var/lib/postgresql
+      - database:/var/lib/postgresql/data
 
   splitpro:
     image: ossapps/splitpro:latest


### PR DESCRIPTION
# Description
Partial revert of https://github.com/oss-apps/split-pro/pull/488.
Relevant upstream pr: [docker-library/postgres#1259](https://redirect.github.com/docker-library/postgres/pull/1259)

The current compose files use the mountpoint for postgres 18 containers (/var/lib/postgresql) on a postgres 17 container. Since the actual mountpoint, defined in the image as /var/lib/postgresql/data, is still free, a new unnamed volume is created for each container, resetting the database with every `docker compose down`.

This pr also locks the image version in the dev setup because this path is not compatible with postgres 18 containers and has to be changed back once the modified image is updated.

Updating the ossapps/postgres image and the reference in docker/prod/compose.yml to postgres 18 would also fix the issue.

# Demo
Relevant output from `docker container inspect`:
```json
"Mounts": [
    {
        "Type": "volume",
        "Name": "98e1897f352060c495bfbae2c661b1b8e06696ea7be0d2f8fd32689bd1b7cf9d",
        "Source": "/var/lib/docker/volumes/98e1897f352060c495bfbae2c661b1b8e06696ea7be0d2f8fd32689bd1b7cf9d/_data",
        "Destination": "/var/lib/postgresql/data",
        "Driver": "local",
        "Mode": "",
        "RW": true,
        "Propagation": ""
    },
    {
        "Type": "volume",
        "Name": "splitpro_database",
        "Source": "/var/lib/docker/volumes/splitpro_database/_data",
        "Destination": "/var/lib/postgresql",
        "Driver": "local",
        "Mode": "rw",
        "RW": true,
        "Propagation": ""
    }
],
```

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [ ] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me
