### PR TITLE
Correctly format amounts of less than 10 cents

### DIFF
--- a/src/tests/number.test.ts
+++ b/src/tests/number.test.ts
@@ -31,6 +31,11 @@ describe('getCurrencyHelpers', () => {
           expect(toUIString(value)).toBe('$1,234');
         });
 
+        it('Should correctly format single digit cent amounts', () => {
+          const value = 7n;
+          expect(toUIString(value)).toBe('$0.07');
+        });
+
         it.each([
           [12345n, '$123.45'],
           [-12345n, '-$123.45'],

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -147,7 +147,7 @@ export const getCurrencyHelpers = ({
     if (typeof value === 'bigint') {
       const sign = value < 0n && signed ? '-' : '';
       const integer = `${value / decimalMultiplierN}`;
-      const fraction = `${value}`.slice(-decimalDigits);
+      const fraction = `${value}`.slice(-decimalDigits).padStart(decimalDigits, '0');
       return (
         sign +
         normalizeToMaxLength(


### PR DESCRIPTION
# Description

Amounts of less than 10 cents are currently formatted incorrectly. For example 1 cent (represented as `1n`) is rendered as `$0.1`. 

When `simplifyDebts` results in very small amounts they render incorrectly and do not add up to the correct debts anymore.

The issue is fixed by padding the string with the appropriate number of zeros.

I've also added a corresponding test.

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [x] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks