### PR TITLE
Exclude settlements from group totals

### DIFF
--- a/src/server/api/routers/group.ts
+++ b/src/server/api/routers/group.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { simplifyDebts } from '~/lib/simplify';
 import { createTRPCRouter, groupProcedure, protectedProcedure } from '~/server/api/trpc';
 import { sendGroupSimplifyDebtsToggleNotification } from '~/server/api/services/notificationService';
+import { SplitType } from '@prisma/client';
 
 export const groupRouter = createTRPCRouter({
   create: protectedProcedure
@@ -152,6 +153,9 @@ export const groupRouter = createTRPCRouter({
       where: {
         groupId: input.groupId,
         deletedAt: null,
+        splitType: {
+          not: SplitType.SETTLEMENT,
+        },
       },
     });
 


### PR DESCRIPTION
# Description
The total expense statistic currently includes settlements as expenses. This is easily fixed by adding another condition to the where query.

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
