### PR TITLE
fix: allow typing minus sign as first character in amount input

### DIFF
--- a/src/tests/number.test.ts
+++ b/src/tests/number.test.ts
@@ -169,6 +169,8 @@ describe('getCurrencyHelpers', () => {
       ['-$1,234.56', '-1234.56'],
       ['abc-123.45xyz', '-123.45'],
       ['--123.45', '-123.45'],
+      ['-', '-'],
+      ['-5', '-5'],
     ])('should sanitize %p to %p with signed flag', (input, expected) => {
       expect(sanitizeInput(input, true)).toBe(expected);
     });

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -113,10 +113,15 @@ export const getCurrencyHelpers = ({
     if (
       signed &&
       hasNegativeSign &&
+      cleaned !== '' &&
       parseFloat(cleaned) !== 0 &&
       !Number.isNaN(parseFloat(cleaned))
     ) {
       cleaned = `-${cleaned}`;
+    }
+    // Allow lone minus sign to persist while user is typing
+    if (signed && hasNegativeSign && cleaned === '') {
+      cleaned = '-';
     }
 
     if (hasDecimalSeparator) {


### PR DESCRIPTION
# Description

When typing a negative expense amount, the minus sign `-` was not accepted as the first character. The user had to type a number first, then place the cursor in front to add the minus sign.

**Root cause:** The `sanitizeInput` function in `src/utils/numbers.ts` only prepended the `-` sign when `parseFloat(cleaned)` was a valid non-zero number. When the input is just `-` with no digits yet, `parseFloat('')` returns `NaN`, causing the minus sign to be stripped.

**Fix:** Added a check to preserve the lone minus sign while the user is typing. When `signed=true`, `hasNegativeSign=true`, and no digits have been entered yet (`cleaned === ''`), the result is now `'-'` instead of `''`.

Closes #621

# Demo

Before fix: typing `-` in the amount field → input stays empty
After fix: typing `-` in the amount field → input shows `-`, then typing digits produces `-5`, `-10.50`, etc.

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [x] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me

# AI Disclosure

This PR was created with the assistance of AI (Hermes Agent). The AI identified the root cause, implemented the fix, added test cases, and prepared this PR description. All changes have been reviewed and verified by the author.
