### PR TITLE
fix: allow typing minus sign first for negative expenses

### DIFF
--- a/src/tests/number.test.ts
+++ b/src/tests/number.test.ts
@@ -169,6 +169,8 @@ describe('getCurrencyHelpers', () => {
       ['-$1,234.56', '-1234.56'],
       ['abc-123.45xyz', '-123.45'],
       ['--123.45', '-123.45'],
+      ['-', '-'],
+      ['-0', '-0'],
     ])('should sanitize %p to %p with signed flag', (input, expected) => {
       expect(sanitizeInput(input, true)).toBe(expected);
     });

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -110,12 +110,7 @@ export const getCurrencyHelpers = ({
         cleaned += letter;
       }
     });
-    if (
-      signed &&
-      hasNegativeSign &&
-      parseFloat(cleaned) !== 0 &&
-      !Number.isNaN(parseFloat(cleaned))
-    ) {
+    if (signed && hasNegativeSign) {
       cleaned = `-${cleaned}`;
     }
 


### PR DESCRIPTION
## Summary

Fixes #621 — when `allowNegative` is enabled, typing `-` as the first character does nothing.

**Root cause:** `sanitizeInput` only prepends the minus sign when the cleaned string parses to a non-zero, non-NaN number. When the input is just `-` (no digits yet), `parseFloat("")` returns `NaN`, so the minus is discarded.

**Fix:** Remove the `parseFloat` guards so the minus sign is preserved immediately, allowing users to type `-5` naturally.

## Changes

- `src/utils/numbers.ts` — simplified the signed-input condition in `sanitizeInput`
- `src/tests/number.test.ts` — added test cases for `-` and `-0` inputs with signed flag

## Test plan

- [x] Added test cases for bare `-` and `-0` input with `signed=true`
- [x] Existing signed test cases (`-123.45`, `(-123.45)`, etc.) still pass
- [x] Unsigned mode (`signed=false`) unaffected — minus is still stripped