### PR TITLE
Update .env.example for app to gat a connection to the db and also used the valtaibles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,8 @@ POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="strong-password"
 POSTGRES_DB="splitpro"
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@splitpro-db:5432/${POSTGRES_DB} # Use this for pod deployments
-# DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB} # Use this for dev deployments
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@splitpro-db:5432/${POSTGRES_DB} # Use this for prod deployments
+# DATABASE_URL="postgresql://postgres:strong-password@localhost:5432/splitpro" # Use this for dev deployments
 
 # Next Auth
 # You should generate a new secret on the command line with:

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="strong-password"
 POSTGRES_DB="splitpro"
 POSTGRES_PORT=5432
-DATABASE_URL="postgresql://postgres:strong-password@localhost:5432/splitpro"
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@splitpro-db:5432/${POSTGRES_DB}
 
 # Next Auth
 # You should generate a new secret on the command line with:

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,8 @@ POSTGRES_USER="postgres"
 POSTGRES_PASSWORD="strong-password"
 POSTGRES_DB="splitpro"
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@splitpro-db:5432/${POSTGRES_DB}
+DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@splitpro-db:5432/${POSTGRES_DB} # Use this for pod deployments
+# DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB} # Use this for dev deployments
 
 # Next Auth
 # You should generate a new secret on the command line with:


### PR DESCRIPTION
# 🔧 Fix database connection configuration

## Description
This PR updates the `.env.example` to correct the PostgreSQL connection configuration for Docker-based setups.

Previously, the `DATABASE_URL` pointed to `localhost`, which breaks containerized deployments where the database runs in a separate Docker service. This update ensures the application correctly connects to the `splitpro-db` service inside the Docker network.

---

## Changes

### ✅ Updated `.env.example`

**Old configuration:**
```env
POSTGRES_PASSWORD="strong-password"
POSTGRES_DB="splitpro"
POSTGRES_PORT=5432
DATABASE_URL="postgresql://postgres:strong-password@localhost:5432/splitpro"
```
**New configuration:**
```env
POSTGRES_USER="postgres"
POSTGRES_PASSWORD="strong-password"
POSTGRES_DB="splitpro"
POSTGRES_PORT=5432
DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@splitpro-db:5432/${POSTGRES_DB}
```