### PR TITLE
Enable filtering currencies by name.

### DIFF
--- a/src/components/AddExpense/CurrencyPicker.tsx
+++ b/src/components/AddExpense/CurrencyPicker.tsx
@@ -76,6 +76,17 @@ function CurrencyPickerInner({
     [],
   );
   const extractKey = extractValue;
+  const extractKeywords = useCallback(
+    (currency: { code: CurrencyCode } | { code: '__CLEAR__' }) => {
+      if ('__CLEAR__' === currency.code) {
+        return [];
+      }
+
+      const translatedName = getCurrencyName(currency.code);
+      return [translatedName];
+    },
+    [getCurrencyName],
+  );
   const selectedOption = useCallback(
     (currency: { code: CurrencyCode } | { code: '__CLEAR__' }) =>
       '__CLEAR__' === currency.code ? currentCurrency === null : currency.code === currentCurrency,
@@ -110,6 +121,7 @@ function CurrencyPickerInner({
       items={renderedItems}
       extractValue={extractValue}
       extractKey={extractKey}
+      extractKeywords={extractKeywords}
       selected={selectedOption}
       render={renderCurrencyItem}
     />

--- a/src/components/GeneralPicker.tsx
+++ b/src/components/GeneralPicker.tsx
@@ -11,6 +11,7 @@ export const GeneralPicker: React.FC<{
   items: any[];
   extractValue: (item: any) => string;
   extractKey: (item: any) => string;
+  extractKeywords?: (item: any) => string[];
   selected: (item: any) => boolean;
   render: (item: any) => React.ReactNode;
   placeholderText: string;
@@ -23,6 +24,7 @@ export const GeneralPicker: React.FC<{
   items,
   extractValue,
   extractKey,
+  extractKeywords,
   render,
   placeholderText,
   noOptionsText,
@@ -56,6 +58,7 @@ export const GeneralPicker: React.FC<{
             <CommandItem
               key={extractKey(item)}
               value={extractValue(item)}
+              keywords={extractKeywords ? extractKeywords(item) : []}
               onSelect={onSelectAndClose}
               className="flex cursor-pointer items-center"
             >


### PR DESCRIPTION
Fixes #636.

# Description
Use the keywords property of CommandItem which can receive extra arguments to filter for.

# Demo
<img width="1445" height="1214" alt="splitpro" src="https://github.com/user-attachments/assets/12867e58-20f4-4e5c-aaa9-99e735a0f469" />

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me (none)
