### PR TITLE
fix(LanguagePicker): use the language-specific empty-state key

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,6 +5,7 @@
       "messages": {
         "language_changed": "Language changed successfully"
       },
+      "no_language_found": "No language found.",
       "placeholder": "Select a language",
       "title": "Select a language"
     },

--- a/src/components/Account/LanguagePicker.tsx
+++ b/src/components/Account/LanguagePicker.tsx
@@ -45,7 +45,7 @@ export const LanguagePicker: React.FC<PropsWithChildren> = ({ children }) => {
       trigger={children}
       title={t('account.change_language_details.title')}
       placeholderText={t('account.change_language_details.placeholder')}
-      noOptionsText={t('account.change_language_details.no_currency_found')}
+      noOptionsText={t('account.change_language_details.no_language_found')}
       onSelect={onSelect}
       items={supportedLanguages}
       extractValue={extractKey}


### PR DESCRIPTION
Closes #635.

## What

When the language picker's search filter matched nothing, the picker rendered the raw i18n key `ui.change_language_details.no_currency_found` instead of a translated string.

`LanguagePicker` was looking up `account.change_language_details.no_currency_found`, which is not defined in the language sub-tree of `public/locales/en/common.json` (only `title`, `placeholder`, and `messages.language_changed` exist there). `no_currency_found` is a sibling of the currency picker's locale tree, not the language picker's.

## Change

- `src/components/Account/LanguagePicker.tsx`: switch `noOptionsText` lookup to `account.change_language_details.no_language_found`.
- `public/locales/en/common.json`: add `"no_language_found": "No language found."` next to `title`/`placeholder` in `account.change_language_details`. Per CONTRIBUTING.md, the other locales pick this key up through the existing Weblate flow.

## Test plan

1. `pnpm dev`, sign in, open Account → Change language.
2. Type `asdasd` in the picker.
3. Expect "No language found." instead of `ui.change_language_details.no_currency_found`.

## AI disclosure

Drafted with AI assistance (Claude). The diff is minimal and reviewed manually.