### PR TITLE
Fix missing ui.not_set translation key in all locales

### DIFF
--- a/public/locales/cs/common.json
+++ b/public/locales/cs/common.json
@@ -400,6 +400,7 @@
     "in_group": "Ve skupině",
     "no_activity": "Zatím žádná aktivita",
     "not_involved": "Nezúčastněn",
+    "not_set": "Nenastaveno",
     "on": "zapnuto",
     "or": "nebo",
     "outstanding_balances": "Zbývající dluhy",

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -403,6 +403,7 @@
     "in_group": "Grupiert",
     "no_activity": "Noch keine Aktivitäten",
     "not_involved": "Nicht beteiligt",
+    "not_set": "Nicht festgelegt",
     "on": "am",
     "or": "oder",
     "outstanding_balances": "Ausstehende Salden",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -429,6 +429,7 @@
     "expense_details": "Expense details",
     "no_activity": "No activities yet",
     "not_involved": "Not involved",
+    "not_set": "Not set",
     "on": "on",
     "or": "or",
     "outstanding_balances": "Outstanding balances",

--- a/public/locales/es-AR/common.json
+++ b/public/locales/es-AR/common.json
@@ -404,6 +404,7 @@
     "in_group": "En grupo",
     "no_activity": "Aún no hay actividades",
     "not_involved": "No involucrado",
+    "not_set": "No establecido",
     "on": "el",
     "or": "o",
     "outstanding_balances": "Saldos pendientes",

--- a/public/locales/es-MX/common.json
+++ b/public/locales/es-MX/common.json
@@ -403,6 +403,7 @@
     "in_group": "En grupo",
     "no_activity": "Aún no hay actividades",
     "not_involved": "No involucrado",
+    "not_set": "No establecido",
     "on": "el",
     "or": "o",
     "outstanding_balances": "Saldos pendientes",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -400,6 +400,7 @@
     "in_group": "En grupo",
     "no_activity": "Sin actividad",
     "not_involved": "No involucrado",
+    "not_set": "No establecido",
     "on": "el",
     "or": "o",
     "outstanding_balances": "Saldos pendientes",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -430,6 +430,7 @@
     "in_group": "dans le groupe",
     "no_activity": "Aucune activité pour l'instant",
     "not_involved": "Non concerné⋅e",
+    "not_set": "Non défini",
     "on": "le",
     "or": "ou",
     "outstanding_balances": "Soldes en cours",

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -400,6 +400,7 @@
     "in_group": "",
     "no_activity": "",
     "not_involved": "",
+    "not_set": "לא מוגדר",
     "on": "",
     "or": "",
     "outstanding_balances": "",

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -400,6 +400,7 @@
     "in_group": "",
     "no_activity": "",
     "not_involved": "",
+    "not_set": "सेट नहीं",
     "on": "",
     "or": "",
     "outstanding_balances": "",

--- a/public/locales/hu/common.json
+++ b/public/locales/hu/common.json
@@ -430,6 +430,7 @@
     "in_group": "Csoportban",
     "no_activity": "Még nincsenek tevékenységek",
     "not_involved": "Nem vesz részt",
+    "not_set": "Nincs beállítva",
     "on": "ekkor",
     "or": "vagy",
     "outstanding_balances": "Kiegyenlítetlen egyenlegek",

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -405,6 +405,7 @@
     "in_group": "Nel gruppo",
     "no_activity": "Nessuna attività ancora",
     "not_involved": "Non coinvolto",
+    "not_set": "Non impostato",
     "on": "il",
     "or": "o",
     "outstanding_balances": "Saldi in sospeso",

--- a/public/locales/ne/common.json
+++ b/public/locales/ne/common.json
@@ -425,6 +425,7 @@
     "in_group": "समूहमा",
     "no_activity": "कुनै गतिविधि छैन",
     "not_involved": "संलग्न नभएको",
+    "not_set": "सेट गरिएको छैन",
     "on": "मा",
     "or": "वा",
     "outstanding_balances": "बाँकी रहेका हिसाबहरू",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -400,6 +400,7 @@
     "in_group": "",
     "no_activity": "",
     "not_involved": "",
+    "not_set": "Niet ingesteld",
     "on": "",
     "or": "of",
     "outstanding_balances": "",

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -412,6 +412,7 @@
     "in_group": "",
     "no_activity": "Brak aktywności",
     "not_involved": "Nie uczestniczy",
+    "not_set": "Nie ustawiono",
     "on": "dnia",
     "or": "lub",
     "outstanding_balances": "Zaległe salda",

--- a/public/locales/pt-BR/common.json
+++ b/public/locales/pt-BR/common.json
@@ -430,6 +430,7 @@
     "in_group": "Em grupo",
     "no_activity": "Nenhuma atividade ainda",
     "not_involved": "Não está envolvido(a)",
+    "not_set": "Não definido",
     "on": "em",
     "or": "ou",
     "outstanding_balances": "Saldos pendentes",

--- a/public/locales/pt-PT/common.json
+++ b/public/locales/pt-PT/common.json
@@ -404,6 +404,7 @@
     "in_group": "",
     "no_activity": "Ainda sem atividade",
     "not_involved": "Não envolvido",
+    "not_set": "Não definido",
     "on": "em",
     "or": "ou",
     "outstanding_balances": "Saldos em aberto",

--- a/public/locales/sk/common.json
+++ b/public/locales/sk/common.json
@@ -400,6 +400,7 @@
     "in_group": "V skupine",
     "no_activity": "Zatiaľ žiadne aktivity",
     "not_involved": "Nezúčastnil sa",
+    "not_set": "Nenastavené",
     "on": "na",
     "or": "alebo",
     "outstanding_balances": "Neuhradené zostatky",

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -430,6 +430,7 @@
     "in_group": "I grupp",
     "no_activity": "Inga aktiviteter än",
     "not_involved": "Inte involverad",
+    "not_set": "Inte inställt",
     "on": "på",
     "or": "eller",
     "outstanding_balances": "Saldon",

--- a/public/locales/zh-Hant/common.json
+++ b/public/locales/zh-Hant/common.json
@@ -400,6 +400,7 @@
     "in_group": "",
     "no_activity": "",
     "not_involved": "",
+    "not_set": "未設定",
     "on": "",
     "or": "",
     "outstanding_balances": "",


### PR DESCRIPTION
## Summary

\`src/components/AddExpense/CurrencyPicker.tsx\` references \`t('ui.not_set')\` for the "clear selection" entry, but the key was missing from every locale file. Users saw the raw key \`ui.not_set\` rendered in the UI when no currency was selected (e.g. user profile, group default currency).

## Changes

- Adds \`"not_set"\` under the top-level \`"ui"\` section in all 19 locales that contain a \`ui\` section.
- Three locales (\`ja\`, \`ru\`, \`sq\`) have no \`ui\` section at all and will fall back to the English value via i18next — no change needed there.

## Test plan

- [ ] In each locale, open the user profile or a group settings page where no default currency is set. The placeholder should render as the translated "Not set" text, not the raw key \`ui.not_set\`.

## Disclaimer

The non-English translations were drafted with the help of Claude Opus 4.7 and have not been native-speaker reviewed. Maintainers may want to review or replace them.