### PR TITLE
feat(import): add Splitwise API import for full expense history

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -31,6 +31,7 @@
     },
     "follow_on_x": "Follow us on X",
     "import_from_splitwise": "Import from Splitwise",
+    "import_from_splitwise_api": "Import from Splitwise (API)",
     "import_from_splitwise_details": {
       "choose_file": "Choose file",
       "export_splitwise_data_button": "Export splitwise data",

--- a/src/lib/splitwise-api.ts
+++ b/src/lib/splitwise-api.ts
@@ -1,0 +1,304 @@
+/**
+ * Splitwise API Service
+ *
+ * Provides methods to fetch data from Splitwise API for importing
+ * expenses into SplitPro with complete accuracy.
+ */
+
+const API_BASE = 'https://secure.splitwise.com/api/v3.0';
+
+// ============= TYPES =============
+
+export interface SplitwiseUserShare {
+  user_id: number;
+  user: {
+    id: number;
+    first_name: string;
+    last_name: string | null;
+    email: string;
+    picture?: {
+      medium?: string;
+    };
+  };
+  paid_share: string;
+  owed_share: string;
+  net_balance: string;
+}
+
+export interface SplitwiseExpense {
+  id: number;
+  cost: string;
+  description: string;
+  details: string | null;
+  date: string;
+  currency_code: string;
+  category: {
+    id: number;
+    name: string;
+  };
+  group_id: number | null;
+  friendship_id: number | null;
+  expense_bundle_id: number | null;
+  repeats: boolean;
+  repeat_interval: string | null;
+  email_reminder: boolean;
+  email_reminder_in_advance: number | null;
+  next_repeat: string | null;
+  comments_count: number;
+  payment: boolean;
+  transaction_confirmed: boolean;
+  created_at: string;
+  created_by: {
+    id: number;
+    first_name: string;
+    last_name: string | null;
+  };
+  updated_at: string;
+  updated_by: {
+    id: number;
+    first_name: string;
+    last_name: string | null;
+  } | null;
+  deleted_at: string | null;
+  deleted_by: {
+    id: number;
+    first_name: string;
+    last_name: string | null;
+  } | null;
+  users: SplitwiseUserShare[];
+  repayments: {
+    from: number;
+    to: number;
+    amount: string;
+  }[];
+}
+
+export interface SplitwiseGroupMember {
+  id: number;
+  first_name: string;
+  last_name: string | null;
+  email: string;
+  registration_status: string;
+  picture?: {
+    medium?: string;
+  };
+  balance: {
+    currency_code: string;
+    amount: string;
+  }[];
+}
+
+export interface SplitwiseGroup {
+  id: number;
+  name: string;
+  group_type: string;
+  updated_at: string;
+  created_at: string;
+  simplify_by_default: boolean;
+  members: SplitwiseGroupMember[];
+  original_debts: {
+    from: number;
+    to: number;
+    amount: string;
+    currency_code: string;
+  }[];
+  simplified_debts: {
+    from: number;
+    to: number;
+    amount: string;
+    currency_code: string;
+  }[];
+}
+
+export interface SplitwiseFriend {
+  id: number;
+  first_name: string;
+  last_name: string | null;
+  email: string;
+  registration_status: string;
+  picture?: {
+    medium?: string;
+  };
+  balance: {
+    currency_code: string;
+    amount: string;
+  }[];
+  groups: {
+    group_id: number;
+    balance: Array<{
+      currency_code: string;
+      amount: string;
+    }>;
+  }[];
+}
+
+export interface SplitwiseCurrentUser {
+  id: number;
+  first_name: string;
+  last_name: string | null;
+  email: string;
+  picture?: {
+    medium?: string;
+  };
+  default_currency: string;
+}
+
+// ============= API CLIENT =============
+
+export class SplitwiseApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public statusText: string,
+  ) {
+    super(message);
+    this.name = 'SplitwiseApiError';
+  }
+}
+
+async function fetchFromSplitwise<T>(
+  endpoint: string,
+  apiKey: string,
+  params?: Record<string, string | number>,
+): Promise<T> {
+  const url = new URL(`${API_BASE}${endpoint}`);
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      url.searchParams.append(key, String(value));
+    });
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new SplitwiseApiError(
+      `Splitwise API request failed: ${response.status} ${response.statusText}`,
+      response.status,
+      response.statusText,
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+// ============= API METHODS =============
+
+/**
+ * Get current user info to validate API key
+ */
+export async function getCurrentUser(apiKey: string): Promise<SplitwiseCurrentUser> {
+  const response = await fetchFromSplitwise<{
+    user: SplitwiseCurrentUser;
+  }>('/get_current_user', apiKey);
+  return response.user;
+}
+
+/**
+ * Get all groups for the current user
+ */
+export async function getGroups(apiKey: string): Promise<SplitwiseGroup[]> {
+  const response = await fetchFromSplitwise<{ groups: SplitwiseGroup[] }>('/get_groups', apiKey);
+  // Filter out the "Non-group expenses" (id: 0)
+  return response.groups.filter((g) => g.id !== 0);
+}
+
+/**
+ * Get all friends for the current user
+ */
+export async function getFriends(apiKey: string): Promise<SplitwiseFriend[]> {
+  const response = await fetchFromSplitwise<{ friends: SplitwiseFriend[] }>('/get_friends', apiKey);
+  return response.friends;
+}
+
+/**
+ * Get expenses for a specific group with pagination
+ */
+export async function getGroupExpenses(
+  apiKey: string,
+  groupId: number,
+  options: {
+    limit?: number;
+    offset?: number;
+    datedAfter?: string;
+    datedBefore?: string;
+  } = {},
+): Promise<SplitwiseExpense[]> {
+  const params: Record<string, string | number> = {
+    group_id: groupId,
+    limit: options.limit ?? 100,
+    offset: options.offset ?? 0,
+  };
+
+  if (options.datedAfter) {
+    params.dated_after = options.datedAfter;
+  }
+  if (options.datedBefore) {
+    params.dated_before = options.datedBefore;
+  }
+
+  const response = await fetchFromSplitwise<{ expenses: SplitwiseExpense[] }>(
+    '/get_expenses',
+    apiKey,
+    params,
+  );
+
+  return response.expenses;
+}
+
+/**
+ * Get ALL expenses for a group (handles pagination automatically)
+ */
+export async function getAllGroupExpenses(
+  apiKey: string,
+  groupId: number,
+  onProgress?: (fetched: number, total: number | null) => void,
+): Promise<SplitwiseExpense[]> {
+  const allExpenses: SplitwiseExpense[] = [];
+  const limit = 100;
+  let offset = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const expenses = await getGroupExpenses(apiKey, groupId, { limit, offset });
+
+    // Filter out deleted expenses
+    const activeExpenses = expenses.filter((e) => !e.deleted_at);
+    allExpenses.push(...activeExpenses);
+
+    onProgress?.(allExpenses.length, null);
+
+    if (expenses.length < limit) {
+      hasMore = false;
+    } else {
+      offset += limit;
+    }
+  }
+
+  return allExpenses;
+}
+
+/**
+ * Validate API key by trying to fetch current user
+ */
+export async function validateApiKey(
+  apiKey: string,
+): Promise<{ valid: boolean; user?: SplitwiseCurrentUser; error?: string }> {
+  try {
+    const user = await getCurrentUser(apiKey);
+    return { valid: true, user };
+  } catch (error) {
+    if (error instanceof SplitwiseApiError) {
+      if (error.status === 401) {
+        return { valid: false, error: 'Invalid API key' };
+      }
+      return { valid: false, error: error.message };
+    }
+    return { valid: false, error: 'Failed to validate API key' };
+  }
+}

--- a/src/lib/splitwise-converter.ts
+++ b/src/lib/splitwise-converter.ts
@@ -1,0 +1,208 @@
+/**
+ * Splitwise to SplitPro Conversion Utilities
+ *
+ * Converts Splitwise expense data to SplitPro format.
+ * Extracted for testability.
+ */
+
+import { SplitType } from '@prisma/client';
+import { type SplitwiseExpense } from './splitwise-api';
+
+export interface ConvertedExpense {
+  name: string;
+  category: string;
+  amount: bigint;
+  currency: string;
+  splitType: SplitType;
+  expenseDate: Date;
+  createdAt: Date;
+  paidBy: number;
+  groupId: number;
+  participants: { userId: number; amount: bigint }[];
+  transactionId: string;
+}
+
+/**
+ * Convert Splitwise expense to SplitPro expense data
+ * Uses Splitwise user ID to map to our DB user ID
+ *
+ * @param expense - The Splitwise expense to convert
+ * @param splitwiseIdToDbId - Map from Splitwise user ID to SplitPro DB user ID
+ * @param groupId - The SplitPro group ID
+ * @returns Converted expense data or null if conversion fails
+ */
+export function convertExpenseToSplitPro(
+  expense: SplitwiseExpense,
+  splitwiseIdToDbId: Map<number, number>,
+  groupId: number,
+): ConvertedExpense | null {
+  // Find the payer (user with paid_share > 0)
+  const payer = expense.users.find((u) => parseFloat(u.paid_share) > 0);
+
+  if (!payer) {
+    console.warn(`No payer found for expense: ${expense.description}`);
+    return null;
+  }
+
+  // Use user_id from the expense data to look up DB user
+  const payerDbId = splitwiseIdToDbId.get(payer.user_id);
+  if (!payerDbId) {
+    console.warn(`Payer not found in DB: Splitwise ID ${payer.user_id}`);
+    return null;
+  }
+
+  // Convert cost to BigInt (paisa/cents)
+  const totalAmount = BigInt(Math.round(parseFloat(expense.cost) * 100));
+
+  // Build participants
+  const participants: { userId: number; amount: bigint }[] = [];
+
+  for (const userShare of expense.users) {
+    const userId = splitwiseIdToDbId.get(userShare.user_id);
+    if (!userId) {
+      console.warn(`User not found in DB: Splitwise ID ${userShare.user_id}`);
+      continue;
+    }
+
+    const paidShare = parseFloat(userShare.paid_share);
+    const owedShare = parseFloat(userShare.owed_share);
+
+    // Calculate participant amount using SplitPro's model:
+    // - If they paid: amount = -owedShare + paidShare
+    // - If they didn't pay: amount = -owedShare
+    let participantAmount: bigint;
+    if (paidShare > 0) {
+      // This is a payer
+      participantAmount = BigInt(Math.round((-owedShare + paidShare) * 100));
+    } else {
+      // Non-payer
+      participantAmount = BigInt(Math.round(-owedShare * 100));
+    }
+
+    // Skip zero amounts
+    if (0n === participantAmount) {
+      continue;
+    }
+
+    participants.push({
+      userId,
+      amount: participantAmount,
+    });
+  }
+
+  if (participants.length === 0) {
+    console.warn(`No participants for expense: ${expense.description}`);
+    return null;
+  }
+
+  // Determine split type
+  const splitType = determineSplitType(expense);
+
+  return {
+    name: expense.description || 'Untitled expense',
+    category: expense.category?.name?.toLowerCase() || 'general',
+    amount: totalAmount,
+    currency: expense.currency_code,
+    splitType,
+    expenseDate: new Date(expense.date),
+    createdAt: new Date(expense.created_at),
+    paidBy: payerDbId,
+    groupId,
+    participants,
+    transactionId: `splitwise-api-${expense.id}`,
+  };
+}
+
+/**
+ * Determine the split type based on expense data
+ */
+export function determineSplitType(expense: SplitwiseExpense): SplitType {
+  if (expense.payment) {
+    return SplitType.SETTLEMENT;
+  }
+
+  // Check if it's an equal split
+  const shares = expense.users.map((u) => parseFloat(u.owed_share)).filter((s) => s > 0);
+  const uniqueShares = new Set(shares.map((s) => s.toFixed(2)));
+
+  if (uniqueShares.size === 1 && shares.length > 1) {
+    return SplitType.EQUAL;
+  }
+
+  return SplitType.EXACT;
+}
+
+/**
+ * Map Splitwise category to SplitPro category
+ */
+export function mapCategory(splitwiseCategory: string): string {
+  const categoryMap: Record<string, string> = {
+    groceries: 'food',
+    'dining out': 'food',
+    food: 'food',
+    drinks: 'food',
+    liquor: 'food',
+    rent: 'home',
+    mortgage: 'home',
+    household: 'home',
+    furniture: 'home',
+    maintenance: 'home',
+    pets: 'home',
+    services: 'home',
+    electronics: 'home',
+    utilities: 'utilities',
+    electricity: 'utilities',
+    heat: 'utilities',
+    water: 'utilities',
+    tv: 'utilities',
+    internet: 'utilities',
+    trash: 'utilities',
+    cleaning: 'utilities',
+    transportation: 'transportation',
+    parking: 'transportation',
+    car: 'transportation',
+    bus: 'transportation',
+    train: 'transportation',
+    plane: 'transportation',
+    taxi: 'transportation',
+    bicycle: 'transportation',
+    hotel: 'transportation',
+    gas: 'transportation',
+    entertainment: 'entertainment',
+    games: 'entertainment',
+    movies: 'entertainment',
+    music: 'entertainment',
+    sports: 'entertainment',
+    clothing: 'personal',
+    gifts: 'personal',
+    medical: 'personal',
+    insurance: 'personal',
+    taxes: 'personal',
+    education: 'personal',
+    childcare: 'personal',
+    general: 'general',
+    payment: 'general',
+    other: 'general',
+  };
+
+  return categoryMap[splitwiseCategory.toLowerCase()] || 'general';
+}
+
+/**
+ * Calculate the participant amount for SplitPro's model
+ *
+ * In SplitPro:
+ * - Payer gets: total - their_share (positive, they are owed money)
+ * - Non-payer gets: -their_share (negative, they owe money)
+ *
+ * From Splitwise:
+ * - paid_share: how much they paid
+ * - owed_share: how much they owe (their share of the expense)
+ *
+ * Formula: amount = paid_share - owed_share
+ * - If paid_share > owed_share: positive (they are owed)
+ * - If paid_share < owed_share: negative (they owe)
+ */
+export function calculateParticipantAmount(paidShare: number, owedShare: number): bigint {
+  return BigInt(Math.round((paidShare - owedShare) * 100));
+}

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -172,6 +172,11 @@ const AccountPage: NextPageWithUser<{
             {t('account.import_from_splitwise')}
           </AccountButton>
 
+          <AccountButton href="/import-splitwise-api">
+            <DownloadCloud className="size-5 text-emerald-500" />
+            {t('account.import_from_splitwise_api')}
+          </AccountButton>
+
           <DebugInfo>
             <AccountButton>
               <BadgeInfo className="size-5 text-red-700" />

--- a/src/pages/import-splitwise-api.tsx
+++ b/src/pages/import-splitwise-api.tsx
@@ -1,0 +1,356 @@
+/**
+ * Splitwise API Import Page
+ *
+ * Imports complete expense history from Splitwise using their API.
+ * Provides 100% accurate import with full expense details.
+ */
+
+import { CheckCircle, Key, Loader2, XCircle } from 'lucide-react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useState } from 'react';
+import { toast } from 'sonner';
+import MainLayout from '~/components/Layout/MainLayout';
+import { Button } from '~/components/ui/button';
+import { Checkbox } from '~/components/ui/checkbox';
+import { Input } from '~/components/ui/input';
+import { Separator } from '~/components/ui/separator';
+import { type NextPageWithUser } from '~/types';
+import { api } from '~/utils/api';
+import { withI18nStaticProps } from '~/utils/i18n/server';
+
+type ImportStatus = 'idle' | 'importing' | 'success' | 'error';
+
+interface GroupImportState {
+  status: ImportStatus;
+  imported?: number;
+  skipped?: number;
+  total?: number;
+  error?: string;
+}
+
+const ImportSplitwiseApiPage: NextPageWithUser = () => {
+  const [apiKey, setApiKey] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [isValidated, setIsValidated] = useState(false);
+  const [userName, setUserName] = useState('');
+  const [selectedGroups, setSelectedGroups] = useState<Record<number, boolean>>({});
+  const [importStatus, setImportStatus] = useState<Record<number, GroupImportState>>({});
+
+  // Validate API key mutation
+  const validateMutation = api.splitwiseApiImport.validateKey.useMutation();
+
+  // Get groups query (enabled only after validation)
+  const groupsQuery = api.splitwiseApiImport.getGroups.useQuery(
+    { apiKey },
+    { enabled: isValidated && apiKey.length > 0 },
+  );
+
+  // Import group mutation
+  const importMutation = api.splitwiseApiImport.importGroup.useMutation();
+
+  const handleValidateKey = async () => {
+    if (!apiKey.trim()) {
+      toast.error('Please enter your Splitwise API key');
+      return;
+    }
+
+    setIsValidating(true);
+    try {
+      const result = await validateMutation.mutateAsync({ apiKey });
+      if (result.valid && result.user) {
+        setIsValidated(true);
+        setUserName(
+          `${result.user.first_name}${result.user.last_name ? ` ${result.user.last_name}` : ''}`,
+        );
+        toast.success(`Connected as ${result.user.first_name}`);
+      } else {
+        toast.error(result.error || 'Invalid API key');
+      }
+    } catch (error) {
+      toast.error('Failed to validate API key');
+    } finally {
+      setIsValidating(false);
+    }
+  };
+
+  const handleImportSelected = async () => {
+    const selectedGroupIds = Object.entries(selectedGroups)
+      .filter(([, selected]) => selected)
+      .map(([id]) => Number(id));
+
+    if (selectedGroupIds.length === 0) {
+      toast.error('Please select at least one group to import');
+      return;
+    }
+
+    const groups = groupsQuery.data || [];
+
+    // Import groups sequentially
+    for (const groupId of selectedGroupIds) {
+      const group = groups.find((g) => g.id === groupId);
+      if (!group) {
+        continue;
+      }
+
+      setImportStatus((prev) => ({
+        ...prev,
+        [groupId]: { status: 'importing' },
+      }));
+
+      try {
+        const result = await importMutation.mutateAsync({
+          apiKey,
+          groupId,
+          groupName: group.name,
+        });
+
+        setImportStatus((prev) => ({
+          ...prev,
+          [groupId]: {
+            status: 'success',
+            imported: result.imported,
+            skipped: result.skipped,
+            total: result.total,
+          },
+        }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        setImportStatus((prev) => ({
+          ...prev,
+          [groupId]: { status: 'error', error: message },
+        }));
+      }
+    }
+
+    toast.success('Import completed!');
+  };
+
+  const handleSelectAll = () => {
+    const groups = groupsQuery.data || [];
+    const allSelected = groups.every((g) => selectedGroups[g.id]);
+
+    if (allSelected) {
+      setSelectedGroups({});
+    } else {
+      const newSelected: Record<number, boolean> = {};
+      groups.forEach((g) => {
+        newSelected[g.id] = true;
+      });
+      setSelectedGroups(newSelected);
+    }
+  };
+
+  const isImporting = Object.values(importStatus).some((s) => s.status === 'importing');
+  const hasSelection = Object.values(selectedGroups).some(Boolean);
+
+  return (
+    <>
+      <Head>
+        <title>Import from Splitwise (API)</title>
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+      <MainLayout hideAppBar>
+        <div className="flex items-center justify-between">
+          <div className="flex gap-4">
+            <Link href="/balances">
+              <Button variant="ghost" className="text-primary px-0 py-0" size="sm">
+                Cancel
+              </Button>
+            </Link>
+          </div>
+          <div className="font-medium">Import from Splitwise</div>
+          <div className="w-[50px]" />
+        </div>
+
+        {/* API Key Section */}
+        <div className="mt-6">
+          <h3 className="text-sm font-medium text-gray-300">Step 1: Connect to Splitwise</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            Enter your Splitwise API key to fetch your groups and expenses.
+          </p>
+
+          <div className="mt-4 flex gap-2">
+            <div className="relative flex-1">
+              <Key className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-500" />
+              <Input
+                type="password"
+                placeholder="Splitwise API key"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                disabled={isValidated}
+                className="pl-10"
+              />
+            </div>
+            {!isValidated ? (
+              <Button onClick={handleValidateKey} disabled={isValidating || !apiKey.trim()}>
+                {isValidating ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Connect'}
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setIsValidated(false);
+                  setApiKey('');
+                  setSelectedGroups({});
+                  setImportStatus({});
+                }}
+              >
+                Disconnect
+              </Button>
+            )}
+          </div>
+
+          {isValidated && <p className="mt-2 text-sm text-green-500">Connected as {userName}</p>}
+
+          <p className="mt-3 text-xs text-gray-500">
+            Get your API key from{' '}
+            <a
+              href="https://secure.splitwise.com/apps"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary underline"
+            >
+              secure.splitwise.com/apps
+            </a>
+          </p>
+        </div>
+
+        {/* Groups Section */}
+        {isValidated && (
+          <div className="mt-8">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium text-gray-300">Step 2: Select Groups to Import</h3>
+              {groupsQuery.data && groupsQuery.data.length > 0 && (
+                <Button variant="ghost" size="sm" onClick={handleSelectAll}>
+                  {groupsQuery.data.every((g) => selectedGroups[g.id])
+                    ? 'Deselect All'
+                    : 'Select All'}
+                </Button>
+              )}
+            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              Choose which groups to import. All expenses will be imported with complete accuracy.
+            </p>
+
+            {groupsQuery.isLoading && (
+              <div className="mt-8 flex items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-gray-500" />
+              </div>
+            )}
+
+            {groupsQuery.error && (
+              <div className="mt-4 rounded-lg bg-red-900/20 p-4 text-red-400">
+                Failed to load groups: {groupsQuery.error.message}
+              </div>
+            )}
+
+            {groupsQuery.data && (
+              <div className="mt-4 flex flex-col gap-3">
+                {groupsQuery.data.map((group, index) => {
+                  const status = importStatus[group.id];
+                  return (
+                    <div key={group.id}>
+                      <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-3">
+                          <Checkbox
+                            checked={selectedGroups[group.id] || false}
+                            onCheckedChange={(checked) => {
+                              setSelectedGroups({
+                                ...selectedGroups,
+                                [group.id]: Boolean(checked),
+                              });
+                            }}
+                            disabled={
+                              status?.status === 'importing' || status?.status === 'success'
+                            }
+                          />
+                          <div>
+                            <p className="font-medium">{group.name}</p>
+                            <p className="text-xs text-gray-500">{group.memberCount} members</p>
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                          {status?.status === 'importing' && (
+                            <div className="flex items-center gap-2 text-yellow-500">
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <span className="text-sm">Importing...</span>
+                            </div>
+                          )}
+                          {status?.status === 'success' && (
+                            <div className="flex items-center gap-2 text-green-500">
+                              <CheckCircle className="h-4 w-4" />
+                              <span className="text-sm">
+                                {status.imported} imported, {status.skipped} skipped
+                              </span>
+                            </div>
+                          )}
+                          {status?.status === 'error' && (
+                            <div className="flex items-center gap-2 text-red-500">
+                              <XCircle className="h-4 w-4" />
+                              <span className="text-sm">{status.error}</span>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                      {index !== groupsQuery.data.length - 1 && <Separator className="mt-3" />}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Import Button */}
+            {groupsQuery.data && groupsQuery.data.length > 0 && (
+              <div className="mt-8">
+                <Button
+                  onClick={handleImportSelected}
+                  disabled={isImporting || !hasSelection}
+                  className="w-full"
+                >
+                  {isImporting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Importing...
+                    </>
+                  ) : (
+                    `Import ${Object.values(selectedGroups).filter(Boolean).length} Group(s)`
+                  )}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Info Section */}
+        <div className="mt-8 rounded-lg bg-gray-900/50 p-4">
+          <h4 className="font-medium">How this works</h4>
+          <ul className="mt-2 space-y-1 text-sm text-gray-400">
+            <li>- Fetches complete expense data directly from Splitwise API</li>
+            <li>- Imports exact payment splits (who paid, who owes what)</li>
+            <li>- Creates accounts for group members using their Splitwise email</li>
+            <li>- Skips duplicate expenses (safe to re-run)</li>
+            <li>- Preserves original expense dates and categories</li>
+          </ul>
+        </div>
+
+        {/* Note about friends */}
+        <div className="mt-4 rounded-lg border border-blue-800/50 bg-blue-900/20 p-4">
+          <h4 className="font-medium text-blue-300">About group members</h4>
+          <p className="mt-1 text-sm text-blue-200/70">
+            When you import a group, accounts are created for all members using their Splitwise
+            email. When your friends sign up to SplitPro using the <strong>same email</strong> they
+            use in Splitwise, they&apos;ll automatically see the imported expenses and groups.
+          </p>
+        </div>
+      </MainLayout>
+    </>
+  );
+};
+
+ImportSplitwiseApiPage.auth = true;
+
+export const getStaticProps = withI18nStaticProps(['common']);
+
+export default ImportSplitwiseApiPage;

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -4,6 +4,7 @@ import { createTRPCRouter } from '~/server/api/trpc';
 import { userRouter } from './routers/user';
 import { bankTransactionsRouter } from './routers/bankTransactions';
 import { expenseRouter } from './routers/expense';
+import { splitwiseApiImportRouter } from './routers/splitwiseApiImport';
 
 /**
  * This is the primary router for your server.
@@ -15,7 +16,8 @@ export const appRouter = createTRPCRouter({
   user: userRouter,
   bankTransactions: bankTransactionsRouter,
   expense: expenseRouter,
+  splitwiseApiImport: splitwiseApiImportRouter,
 });
 
-// export type definition of API
+// Export type definition of API
 export type AppRouter = typeof appRouter;

--- a/src/server/api/routers/splitwiseApiImport.ts
+++ b/src/server/api/routers/splitwiseApiImport.ts
@@ -1,0 +1,254 @@
+/**
+ * Splitwise API Import Router
+ *
+ * Handles importing expenses from Splitwise using their API.
+ * This provides 100% accurate import with complete expense data.
+ */
+
+import { z } from 'zod';
+import { createTRPCRouter, protectedProcedure } from '~/server/api/trpc';
+import { getAllGroupExpenses, getGroups, validateApiKey } from '~/lib/splitwise-api';
+import { nanoid } from 'nanoid';
+import { convertExpenseToSplitPro, mapCategory } from '~/lib/splitwise-converter';
+
+// ============= ROUTER =============
+
+export const splitwiseApiImportRouter = createTRPCRouter({
+  /**
+   * Validate Splitwise API key
+   */
+  validateKey: protectedProcedure
+    .input(z.object({ apiKey: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      const result = await validateApiKey(input.apiKey);
+      return result;
+    }),
+
+  /**
+   * Get groups from Splitwise
+   */
+  getGroups: protectedProcedure
+    .input(z.object({ apiKey: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const groups = await getGroups(input.apiKey);
+
+      // Return groups with summary info
+      return groups.map((group) => ({
+        id: group.id,
+        name: group.name,
+        memberCount: group.members.length,
+        members: group.members.map((m) => ({
+          id: m.id,
+          name: `${m.first_name}${m.last_name ? ` ${m.last_name}` : ''}`,
+          email: m.email,
+          balance: m.balance,
+        })),
+        simplifyByDefault: group.simplify_by_default,
+        createdAt: group.created_at,
+      }));
+    }),
+
+  /**
+   * Import a single group from Splitwise
+   */
+  importGroup: protectedProcedure
+    .input(
+      z.object({
+        apiKey: z.string().min(1),
+        groupId: z.number(),
+        groupName: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const currentUserId = ctx.session.user.id;
+
+      console.info(`Starting import for group: ${input.groupName} (${input.groupId})`);
+
+      // Step 1: Fetch all groups to get member details
+      const groups = await getGroups(input.apiKey);
+      const splitwiseGroup = groups.find((g) => g.id === input.groupId);
+
+      if (!splitwiseGroup) {
+        throw new Error(`Group not found: ${input.groupId}`);
+      }
+
+      // Step 2: Create or find users for all group members
+      // Map Splitwise user ID to our DB user ID
+      const splitwiseIdToDbId = new Map<number, number>();
+
+      for (const member of splitwiseGroup.members) {
+        let user = await ctx.db.user.findUnique({
+          where: { email: member.email },
+        });
+
+        if (!user) {
+          user = await ctx.db.user.create({
+            data: {
+              email: member.email,
+              name: `${member.first_name}${member.last_name ? ` ${member.last_name}` : ''}`,
+              image: member.picture?.medium,
+              currency: 'INR', // Default, can be updated
+            },
+          });
+          console.info(`Created user: ${user.email}`);
+        }
+
+        // Map Splitwise member ID to our DB user ID
+        splitwiseIdToDbId.set(member.id, user.id);
+        console.info(`Mapped Splitwise ID ${member.id} -> DB ID ${user.id} (${member.email})`);
+      }
+
+      // Step 3: Create group in SplitPro (or find existing)
+      let group = await ctx.db.group.findUnique({
+        where: { splitwiseGroupId: input.groupId.toString() },
+      });
+
+      if (group) {
+        console.info(`Group already exists: ${group.name}`);
+
+        // Update group name if it changed in Splitwise
+        if (group.name !== splitwiseGroup.name) {
+          await ctx.db.group.update({
+            where: { id: group.id },
+            data: { name: splitwiseGroup.name },
+          });
+          console.info(`Updated group name: ${group.name} -> ${splitwiseGroup.name}`);
+        }
+
+        // Add any new members that might not be in the group yet
+        for (const member of splitwiseGroup.members) {
+          const userId = splitwiseIdToDbId.get(member.id);
+          if (userId) {
+            const existingMember = await ctx.db.groupUser.findUnique({
+              where: {
+                groupId_userId: {
+                  groupId: group.id,
+                  userId: userId,
+                },
+              },
+            });
+            if (!existingMember) {
+              await ctx.db.groupUser.create({
+                data: {
+                  groupId: group.id,
+                  userId,
+                },
+              });
+              console.info(`Added new member to existing group: ${member.email}`);
+            }
+          }
+        }
+      } else {
+        group = await ctx.db.group.create({
+          data: {
+            name: splitwiseGroup.name,
+            publicId: nanoid(10),
+            userId: currentUserId,
+            defaultCurrency: 'INR',
+            splitwiseGroupId: input.groupId.toString(),
+            simplifyDebts: splitwiseGroup.simplify_by_default,
+            createdAt: new Date(splitwiseGroup.created_at),
+          },
+        });
+        console.info(`Created group: ${group.name}`);
+
+        // Add all members to the group
+        for (const member of splitwiseGroup.members) {
+          const userId = splitwiseIdToDbId.get(member.id);
+          if (userId) {
+            await ctx.db.groupUser.create({
+              data: {
+                groupId: group.id,
+                userId,
+              },
+            });
+          }
+        }
+        console.info(`Added ${splitwiseGroup.members.length} members to group`);
+      }
+
+      // Step 4: Fetch ALL expenses for this group
+      console.info(`Fetching expenses for group: ${input.groupName}...`);
+      const expenses = await getAllGroupExpenses(input.apiKey, input.groupId);
+      console.info(`Fetched ${expenses.length} expenses`);
+
+      // Step 5: Import expenses
+      let imported = 0;
+      let skipped = 0;
+      const errors: string[] = [];
+
+      for (const expense of expenses) {
+        // Skip deleted expenses
+        if (expense.deleted_at) {
+          skipped++;
+          continue;
+        }
+
+        // Check for duplicates
+        const existing = await ctx.db.expense.findFirst({
+          where: {
+            transactionId: `splitwise-api-${expense.id}`,
+          },
+        });
+
+        if (existing) {
+          skipped++;
+          continue;
+        }
+
+        // Convert expense
+        const converted = convertExpenseToSplitPro(expense, splitwiseIdToDbId, group.id);
+
+        if (!converted) {
+          errors.push(`Failed to convert: ${expense.description}`);
+          continue;
+        }
+
+        // Create expense and participants in transaction
+        try {
+          await ctx.db.$transaction(async (tx) => {
+            const createdExpense = await tx.expense.create({
+              data: {
+                name: converted.name,
+                category: mapCategory(converted.category),
+                amount: converted.amount,
+                currency: converted.currency,
+                splitType: converted.splitType,
+                expenseDate: converted.expenseDate,
+                createdAt: converted.createdAt,
+                paidBy: converted.paidBy,
+                addedBy: currentUserId,
+                groupId: converted.groupId,
+                transactionId: converted.transactionId,
+              },
+            });
+
+            await tx.expenseParticipant.createMany({
+              data: converted.participants.map((p) => ({
+                expenseId: createdExpense.id,
+                userId: p.userId,
+                amount: p.amount,
+              })),
+            });
+          });
+
+          imported++;
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          errors.push(`Error importing "${expense.description}": ${msg}`);
+        }
+      }
+
+      console.info(`Import complete: ${imported} imported, ${skipped} skipped`);
+
+      return {
+        success: true,
+        groupId: group.id,
+        groupName: group.name,
+        imported,
+        skipped,
+        total: expenses.length,
+        errors: errors.slice(0, 10), // Return first 10 errors
+      };
+    }),
+});

--- a/src/tests/splitwise-converter.test.ts
+++ b/src/tests/splitwise-converter.test.ts
@@ -1,0 +1,616 @@
+import { SplitType } from '@prisma/client';
+import {
+  calculateParticipantAmount,
+  convertExpenseToSplitPro,
+  determineSplitType,
+  mapCategory,
+} from '~/lib/splitwise-converter';
+import { type SplitwiseExpense } from '~/lib/splitwise-api';
+
+// Suppress console.warn during tests (we're testing error cases intentionally)
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ============= TEST HELPERS =============
+
+/**
+ * Create a mock Splitwise expense for testing
+ */
+function createMockExpense(overrides: Partial<SplitwiseExpense> = {}): SplitwiseExpense {
+  return {
+    id: 1,
+    cost: '100.00',
+    description: 'Test Expense',
+    details: null,
+    date: '2024-01-15T12:00:00Z',
+    currency_code: 'INR',
+    category: { id: 1, name: 'General' },
+    group_id: 1,
+    friendship_id: null,
+    expense_bundle_id: null,
+    repeats: false,
+    repeat_interval: null,
+    email_reminder: false,
+    email_reminder_in_advance: null,
+    next_repeat: null,
+    comments_count: 0,
+    payment: false,
+    transaction_confirmed: true,
+    created_at: '2024-01-15T12:00:00Z',
+    created_by: { id: 1, first_name: 'Test', last_name: 'User' },
+    updated_at: '2024-01-15T12:00:00Z',
+    updated_by: null,
+    deleted_at: null,
+    deleted_by: null,
+    users: [
+      {
+        user_id: 101,
+        user: {
+          id: 101,
+          first_name: 'Alice',
+          last_name: 'Smith',
+          email: 'alice@example.com',
+        },
+        paid_share: '100.00',
+        owed_share: '50.00',
+        net_balance: '50.00',
+      },
+      {
+        user_id: 102,
+        user: {
+          id: 102,
+          first_name: 'Bob',
+          last_name: 'Jones',
+          email: 'bob@example.com',
+        },
+        paid_share: '0.00',
+        owed_share: '50.00',
+        net_balance: '-50.00',
+      },
+    ],
+    repayments: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Create a standard user mapping for tests
+ */
+function createUserMapping(): Map<number, number> {
+  const map = new Map<number, number>();
+  map.set(101, 1); // Splitwise ID 101 -> DB ID 1
+  map.set(102, 2); // Splitwise ID 102 -> DB ID 2
+  map.set(103, 3); // Splitwise ID 103 -> DB ID 3
+  return map;
+}
+
+// ============= TESTS =============
+
+describe('convertExpenseToSplitPro', () => {
+  describe('basic conversion', () => {
+    it('converts a simple two-person equal split expense', () => {
+      const expense = createMockExpense();
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe('Test Expense');
+      expect(result!.amount).toBe(10000n); // 100.00 * 100 = 10000 paisa
+      expect(result!.currency).toBe('INR');
+      expect(result!.groupId).toBe(10);
+      expect(result!.paidBy).toBe(1); // Alice (DB ID 1)
+      expect(result!.transactionId).toBe('splitwise-api-1');
+    });
+
+    it('calculates participant amounts correctly for equal split', () => {
+      // Alice paid 100, split equally (50 each)
+      // Alice: paid 100, owes 50 -> amount = 100 - 50 = +50 (is owed)
+      // Bob: paid 0, owes 50 -> amount = 0 - 50 = -50 (owes)
+      const expense = createMockExpense();
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result!.participants).toHaveLength(2);
+
+      const aliceParticipant = result!.participants.find((p) => p.userId === 1);
+      const bobParticipant = result!.participants.find((p) => p.userId === 2);
+
+      expect(aliceParticipant!.amount).toBe(5000n); // +50.00 (is owed)
+      expect(bobParticipant!.amount).toBe(-5000n); // -50.00 (owes)
+    });
+
+    it('handles three-way equal split', () => {
+      const expense = createMockExpense({
+        cost: '300.00',
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '300.00',
+            owed_share: '100.00',
+            net_balance: '200.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '0.00',
+            owed_share: '100.00',
+            net_balance: '-100.00',
+          },
+          {
+            user_id: 103,
+            user: { id: 103, first_name: 'Charlie', last_name: null, email: 'charlie@example.com' },
+            paid_share: '0.00',
+            owed_share: '100.00',
+            net_balance: '-100.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result!.participants).toHaveLength(3);
+      expect(result!.amount).toBe(30000n);
+
+      const alice = result!.participants.find((p) => p.userId === 1);
+      const bob = result!.participants.find((p) => p.userId === 2);
+      const charlie = result!.participants.find((p) => p.userId === 3);
+
+      expect(alice!.amount).toBe(20000n); // +200 (paid 300, owes 100)
+      expect(bob!.amount).toBe(-10000n); // -100
+      expect(charlie!.amount).toBe(-10000n); // -100
+    });
+  });
+
+  describe('unequal splits', () => {
+    it('handles unequal split correctly', () => {
+      // Alice paid 100, Alice owes 30, Bob owes 70
+      const expense = createMockExpense({
+        cost: '100.00',
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '100.00',
+            owed_share: '30.00',
+            net_balance: '70.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '0.00',
+            owed_share: '70.00',
+            net_balance: '-70.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      const alice = result!.participants.find((p) => p.userId === 1);
+      const bob = result!.participants.find((p) => p.userId === 2);
+
+      expect(alice!.amount).toBe(7000n); // +70 (paid 100, owes 30)
+      expect(bob!.amount).toBe(-7000n); // -70
+    });
+  });
+
+  describe('settlements/payments', () => {
+    it('converts settlement expense correctly', () => {
+      // Bob pays Alice 50 (settling a debt)
+      const expense = createMockExpense({
+        description: 'Payment',
+        cost: '50.00',
+        payment: true,
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '0.00',
+            owed_share: '50.00',
+            net_balance: '-50.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '50.00',
+            owed_share: '0.00',
+            net_balance: '50.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result!.splitType).toBe(SplitType.SETTLEMENT);
+      expect(result!.paidBy).toBe(2); // Bob paid
+
+      const alice = result!.participants.find((p) => p.userId === 1);
+      const bob = result!.participants.find((p) => p.userId === 2);
+
+      expect(alice!.amount).toBe(-5000n); // Alice received payment (owes less now)
+      expect(bob!.amount).toBe(5000n); // Bob made payment (is owed now)
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null when no payer is found', () => {
+      const expense = createMockExpense({
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '0.00',
+            owed_share: '50.00',
+            net_balance: '-50.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '0.00',
+            owed_share: '50.00',
+            net_balance: '-50.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when payer not in user map', () => {
+      const expense = createMockExpense({
+        users: [
+          {
+            user_id: 999, // Not in user map
+            user: { id: 999, first_name: 'Unknown', last_name: null, email: 'unknown@example.com' },
+            paid_share: '100.00',
+            owed_share: '50.00',
+            net_balance: '50.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '0.00',
+            owed_share: '50.00',
+            net_balance: '-50.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result).toBeNull();
+    });
+
+    it('skips participants with zero amounts', () => {
+      // User 103 has zero owed_share and zero paid_share
+      const expense = createMockExpense({
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '100.00',
+            owed_share: '50.00',
+            net_balance: '50.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '0.00',
+            owed_share: '50.00',
+            net_balance: '-50.00',
+          },
+          {
+            user_id: 103,
+            user: { id: 103, first_name: 'Charlie', last_name: null, email: 'charlie@example.com' },
+            paid_share: '0.00',
+            owed_share: '0.00',
+            net_balance: '0.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result!.participants).toHaveLength(2);
+      expect(result!.participants.find((p) => p.userId === 3)).toBeUndefined();
+    });
+
+    it('handles missing description', () => {
+      const expense = createMockExpense({ description: '' });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result!.name).toBe('Untitled expense');
+    });
+
+    it('handles decimal amounts correctly (avoids floating point issues)', () => {
+      const expense = createMockExpense({
+        cost: '33.33',
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '33.33',
+            owed_share: '11.11',
+            net_balance: '22.22',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '0.00',
+            owed_share: '11.11',
+            net_balance: '-11.11',
+          },
+          {
+            user_id: 103,
+            user: { id: 103, first_name: 'Charlie', last_name: null, email: 'charlie@example.com' },
+            paid_share: '0.00',
+            owed_share: '11.11',
+            net_balance: '-11.11',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      expect(result!.amount).toBe(3333n);
+
+      const alice = result!.participants.find((p) => p.userId === 1);
+      const bob = result!.participants.find((p) => p.userId === 2);
+      const charlie = result!.participants.find((p) => p.userId === 3);
+
+      expect(alice!.amount).toBe(2222n);
+      expect(bob!.amount).toBe(-1111n);
+      expect(charlie!.amount).toBe(-1111n);
+    });
+  });
+
+  describe('balance verification', () => {
+    it('participant amounts sum to zero', () => {
+      const expense = createMockExpense();
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      const sum = result!.participants.reduce((acc, p) => acc + p.amount, 0n);
+      expect(sum).toBe(0n);
+    });
+
+    it('participant amounts sum to zero for three-way split', () => {
+      const expense = createMockExpense({
+        cost: '300.00',
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '300.00',
+            owed_share: '100.00',
+            net_balance: '200.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '0.00',
+            owed_share: '100.00',
+            net_balance: '-100.00',
+          },
+          {
+            user_id: 103,
+            user: { id: 103, first_name: 'Charlie', last_name: null, email: 'charlie@example.com' },
+            paid_share: '0.00',
+            owed_share: '100.00',
+            net_balance: '-100.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      const sum = result!.participants.reduce((acc, p) => acc + p.amount, 0n);
+      expect(sum).toBe(0n);
+    });
+
+    it('participant amounts sum to zero for settlement', () => {
+      const expense = createMockExpense({
+        payment: true,
+        cost: '50.00',
+        users: [
+          {
+            user_id: 101,
+            user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+            paid_share: '0.00',
+            owed_share: '50.00',
+            net_balance: '-50.00',
+          },
+          {
+            user_id: 102,
+            user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+            paid_share: '50.00',
+            owed_share: '0.00',
+            net_balance: '50.00',
+          },
+        ],
+      });
+      const userMap = createUserMapping();
+
+      const result = convertExpenseToSplitPro(expense, userMap, 10);
+
+      const sum = result!.participants.reduce((acc, p) => acc + p.amount, 0n);
+      expect(sum).toBe(0n);
+    });
+  });
+});
+
+describe('determineSplitType', () => {
+  it('returns SETTLEMENT for payment expenses', () => {
+    const expense = createMockExpense({ payment: true });
+    expect(determineSplitType(expense)).toBe(SplitType.SETTLEMENT);
+  });
+
+  it('returns EQUAL for equal splits', () => {
+    const expense = createMockExpense({
+      users: [
+        {
+          user_id: 101,
+          user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+          paid_share: '100.00',
+          owed_share: '50.00',
+          net_balance: '50.00',
+        },
+        {
+          user_id: 102,
+          user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+          paid_share: '0.00',
+          owed_share: '50.00',
+          net_balance: '-50.00',
+        },
+      ],
+    });
+    expect(determineSplitType(expense)).toBe(SplitType.EQUAL);
+  });
+
+  it('returns EXACT for unequal splits', () => {
+    const expense = createMockExpense({
+      users: [
+        {
+          user_id: 101,
+          user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+          paid_share: '100.00',
+          owed_share: '30.00',
+          net_balance: '70.00',
+        },
+        {
+          user_id: 102,
+          user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+          paid_share: '0.00',
+          owed_share: '70.00',
+          net_balance: '-70.00',
+        },
+      ],
+    });
+    expect(determineSplitType(expense)).toBe(SplitType.EXACT);
+  });
+
+  it('returns EXACT when only one person owes', () => {
+    const expense = createMockExpense({
+      users: [
+        {
+          user_id: 101,
+          user: { id: 101, first_name: 'Alice', last_name: null, email: 'alice@example.com' },
+          paid_share: '100.00',
+          owed_share: '0.00',
+          net_balance: '100.00',
+        },
+        {
+          user_id: 102,
+          user: { id: 102, first_name: 'Bob', last_name: null, email: 'bob@example.com' },
+          paid_share: '0.00',
+          owed_share: '100.00',
+          net_balance: '-100.00',
+        },
+      ],
+    });
+    expect(determineSplitType(expense)).toBe(SplitType.EXACT);
+  });
+});
+
+describe('mapCategory', () => {
+  it('maps food-related categories to food', () => {
+    expect(mapCategory('groceries')).toBe('food');
+    expect(mapCategory('dining out')).toBe('food');
+    expect(mapCategory('food')).toBe('food');
+    expect(mapCategory('drinks')).toBe('food');
+    expect(mapCategory('liquor')).toBe('food');
+  });
+
+  it('maps home-related categories to home', () => {
+    expect(mapCategory('rent')).toBe('home');
+    expect(mapCategory('mortgage')).toBe('home');
+    expect(mapCategory('household')).toBe('home');
+    expect(mapCategory('furniture')).toBe('home');
+    expect(mapCategory('electronics')).toBe('home');
+  });
+
+  it('maps utility categories to utilities', () => {
+    expect(mapCategory('utilities')).toBe('utilities');
+    expect(mapCategory('electricity')).toBe('utilities');
+    expect(mapCategory('water')).toBe('utilities');
+    expect(mapCategory('internet')).toBe('utilities');
+  });
+
+  it('maps transportation categories to transportation', () => {
+    expect(mapCategory('transportation')).toBe('transportation');
+    expect(mapCategory('parking')).toBe('transportation');
+    expect(mapCategory('taxi')).toBe('transportation');
+    expect(mapCategory('gas')).toBe('transportation');
+  });
+
+  it('maps entertainment categories to entertainment', () => {
+    expect(mapCategory('entertainment')).toBe('entertainment');
+    expect(mapCategory('games')).toBe('entertainment');
+    expect(mapCategory('movies')).toBe('entertainment');
+    expect(mapCategory('music')).toBe('entertainment');
+  });
+
+  it('maps personal categories to personal', () => {
+    expect(mapCategory('clothing')).toBe('personal');
+    expect(mapCategory('gifts')).toBe('personal');
+    expect(mapCategory('medical')).toBe('personal');
+    expect(mapCategory('insurance')).toBe('personal');
+  });
+
+  it('returns general for unknown categories', () => {
+    expect(mapCategory('unknown')).toBe('general');
+    expect(mapCategory('random')).toBe('general');
+    expect(mapCategory('xyz')).toBe('general');
+  });
+
+  it('handles case-insensitive input', () => {
+    expect(mapCategory('GROCERIES')).toBe('food');
+    expect(mapCategory('Rent')).toBe('home');
+    expect(mapCategory('ENTERTAINMENT')).toBe('entertainment');
+  });
+});
+
+describe('calculateParticipantAmount', () => {
+  it('returns positive amount when paid more than owed', () => {
+    // Paid 100, owes 30 -> +70
+    const amount = calculateParticipantAmount(100, 30);
+    expect(amount).toBe(7000n);
+  });
+
+  it('returns negative amount when owed more than paid', () => {
+    // Paid 0, owes 50 -> -50
+    const amount = calculateParticipantAmount(0, 50);
+    expect(amount).toBe(-5000n);
+  });
+
+  it('returns zero when paid equals owed', () => {
+    const amount = calculateParticipantAmount(50, 50);
+    expect(amount).toBe(0n);
+  });
+
+  it('handles decimal values correctly', () => {
+    const amount = calculateParticipantAmount(33.33, 11.11);
+    expect(amount).toBe(2222n);
+  });
+});


### PR DESCRIPTION
  # Description

  Adds direct Splitwise API import for complete expense history with individual transactions.

  **What it does:**
  - Imports individual expenses (not just net balances) with correct `paid_share` / `owed_share` calculations
  - Preserves original `createdAt` timestamps for proper Activity ordering
  - Uses `transactionId` to prevent duplicates (safe to re-run)

  **Files added:**
  - `src/lib/splitwise-api.ts` - API client with pagination
  - `src/lib/splitwise-converter.ts` - Conversion logic
  - `src/server/api/routers/splitwiseApiImport.ts` - tRPC endpoints
  - `src/pages/import-splitwise-api.tsx` - UI for API key entry and group selection
  - `src/tests/splitwise-converter.test.ts` - 29 test cases

  Closes #307
  Related to #465 (different approach - direct API vs external tool)

  ## ⚠️ ToS Discussion Needed

  As noted in #307, Splitwise's API ToS prohibits use for competing services. This PR uses the direct API because the JSON export from export-splitwise only contains **net balances**, not individual expenses.

  **Options to discuss:**
  1. Keep API import with disclaimer (user provides their own key)
  2. Remove and rely on CSV/JSON import only
  3. Other suggestions?

  # Demo

  1. User enters Splitwise API key (from secure.splitwise.com/apps)
  2. Selects groups to import
  3. Expenses imported with full history

  # Checklist

  - [x] I have read `CONTRIBUTING.md` in its entirety
  - [x] I have performed a self-review of my own code
  - [x] I have added unit tests to cover my changes
  - [x] The last commit successfully passed pre-commit checks
  - [x] Any AI code was thoroughly reviewed by me