### PR TITLE
fix: launch PWA at "/" so DEFAULT_HOMEPAGE is respected

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -28,7 +28,7 @@
   ],
   "theme_color": "#030711",
   "background_color": "#030711",
-  "start_url": "/balances",
+  "start_url": "/",
   "display": "standalone",
   "orientation": "portrait",
   "screenshots": [


### PR DESCRIPTION
# Description
Fixes issue #677 by redirecting the start path `/` to `${DEFAULT_HOMEPAGE}` even in a WPA installation. `start_url` in `manifest.json` has been changed to the base path `/`.
Previously, `${DEFAULT_HOMEPAGE}` was only taken into account when a user used Split-Pro in a web browser; however, when installed on a smartphone via PWA, the home page was always redirected to `/balances` (hard-coded in `manifest.json`). Now, if `/` is specified as the start URL, the path is redirected to the path defined in the environment variable by the router.

Closes #677 

# Demo
Visual validation

# Checklist
- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me
