### PR TITLE
feat: add Kanidm OIDC support with PKCE and ID token algo config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,12 @@ OIDC_WELL_KNOWN_URL=
 # Required for some providers to link with existing accounts, make sure you trust your provider to properly verify email addresses
 # OIDC_ALLOW_DANGEROUS_EMAIL_LINKING=1
 
+# Enable PKCE (Proof Key for Code Exchange) for the OIDC provider
+# OIDC_PKCE_ENABLED=1
+
+# Set the ID token signed response algorithm if your provider requires a specific algorithm (e.g. ES256, RS256)
+# OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG=
+
 # Push notification, Web Push: https://www.npmjs.com/package/web-push
 # generate web push keys using this command: npx web-push generate-vapid-keys --json
 # or use the online tool: https://vapidkeys.com/

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -146,20 +146,6 @@ OIDC_CLIENT_SECRET="<client-secret>"
 OIDC_WELL_KNOWN_URL="https://keycloak.example.com/realms/My_Realm/.well-known/openid-configuration"
 ```
 
-### OIDC (Kanidm)
-
-```bash
-DATABASE_URL="postgresql://postgres:strong-password@localhost:5432/splitpro"
-NEXTAUTH_SECRET="<generated>"
-NEXTAUTH_URL="https://splitpro.example.com"
-OIDC_NAME="kanidm"
-OIDC_CLIENT_ID="<client-id>"
-OIDC_CLIENT_SECRET="<client-secret>"
-OIDC_WELL_KNOWN_URL="https://kanidm.example.com/oauth2/openid/<app-name>/.well-known/openid-configuration"
-OIDC_PKCE_ENABLED=1
-OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG=ES256
-```
-
 ## Security notes
 
 - Rotate `NEXTAUTH_SECRET` if it is ever exposed.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -91,6 +91,8 @@ Used for magic-link login and invites.
 - `OIDC_CLIENT_SECRET`
 - `OIDC_WELL_KNOWN_URL`: OpenID well-known discovery URL.
 - `OIDC_ALLOW_DANGEROUS_EMAIL_LINKING`: Optional flag to allow email-based account linking.
+- `OIDC_PKCE_ENABLED`: Optional flag to enable PKCE (Proof Key for Code Exchange).
+- `OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG`: Optional ID token signed response algorithm (e.g. `ES256`, `RS256`).
 
 ### Web push notifications
 
@@ -142,6 +144,20 @@ OIDC_NAME="keycloak"
 OIDC_CLIENT_ID="<client-id>"
 OIDC_CLIENT_SECRET="<client-secret>"
 OIDC_WELL_KNOWN_URL="https://keycloak.example.com/realms/My_Realm/.well-known/openid-configuration"
+```
+
+### OIDC (Kanidm)
+
+```bash
+DATABASE_URL="postgresql://postgres:strong-password@localhost:5432/splitpro"
+NEXTAUTH_SECRET="<generated>"
+NEXTAUTH_URL="https://splitpro.example.com"
+OIDC_NAME="kanidm"
+OIDC_CLIENT_ID="<client-id>"
+OIDC_CLIENT_SECRET="<client-secret>"
+OIDC_WELL_KNOWN_URL="https://kanidm.example.com/oauth2/openid/<app-name>/.well-known/openid-configuration"
+OIDC_PKCE_ENABLED=1
+OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG=ES256
 ```
 
 ## Security notes

--- a/src/env.ts
+++ b/src/env.ts
@@ -71,6 +71,8 @@ export const env = createEnv({
     OIDC_CLIENT_SECRET: z.string().optional(),
     OIDC_WELL_KNOWN_URL: z.string().optional(),
     OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: z.boolean().optional(),
+    OIDC_PKCE_ENABLED: z.boolean().optional().default(false),
+    OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG: z.string().optional(),
     UPLOAD_MAX_FILE_SIZE_MB: z.coerce.number().int().positive().default(10),
   },
 
@@ -140,6 +142,8 @@ export const env = createEnv({
     OIDC_CLIENT_SECRET: process.env.OIDC_CLIENT_SECRET,
     OIDC_WELL_KNOWN_URL: process.env.OIDC_WELL_KNOWN_URL,
     OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: Boolean(process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING),
+    OIDC_PKCE_ENABLED: Boolean(process.env.OIDC_PKCE_ENABLED),
+    OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG: process.env.OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG,
     UPLOAD_MAX_FILE_SIZE_MB: process.env.UPLOAD_MAX_FILE_SIZE_MB
       ? Number(process.env.UPLOAD_MAX_FILE_SIZE_MB)
       : 10,

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,4 +1,5 @@
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { Prisma } from '@prisma/client';
 import { type GetServerSidePropsContext } from 'next';
 import { type DefaultSession, type NextAuthOptions, type User, getServerSession } from 'next-auth';
 import { type Adapter, type AdapterAccount, type AdapterUser } from 'next-auth/adapters';
@@ -71,32 +72,21 @@ const SplitProPrismaAdapter = (...args: Parameters<typeof PrismaAdapter>): Adapt
       return prismaCreateUser(user);
     },
     linkAccount: async (account: AdapterAccount) => {
-      // oxlint-disable-next-line typescript/no-unsafe-assignment
       const originalLinkAccount = prismaAdapter.linkAccount;
-
       if (!originalLinkAccount) {
         throw new Error('Adapter is missing the linkAccount method.');
       }
-
-      // Keycloak and Gitlab provide some non-standard fields that do not exist in the prisma schema.
+      // OIDC providers can provide non-standard fields that do not exist in the prisma schema.
       // We strip them out before passing them on to the original adapter.
-      if (account.provider === 'keycloak') {
-        const {
-          'not-before-policy': _notBeforePolicy,
-          refresh_expires_in: _refresh_expires_in,
-          ...standardAccountData
-        } = account as AdapterAccount & Record<string, unknown>;
+      const knownAccountFields = new Set<string>(Object.values(Prisma.AccountScalarFieldEnum));
 
-        return originalLinkAccount(standardAccountData as AdapterAccount);
-      } else if (account.provider === 'gitlab') {
-        const { created_at: _createdAt, ...standardAccountData } = account as AdapterAccount &
-          Record<string, unknown>;
+      const sanitised = Object.fromEntries(
+        Object.entries(account as Record<string, unknown>).filter(([k]) =>
+          knownAccountFields.has(k),
+        ),
+      ) as AdapterAccount;
 
-        return originalLinkAccount(standardAccountData as AdapterAccount);
-      }
-
-      // Default: proceed directly
-      return originalLinkAccount(account);
+      return originalLinkAccount(sanitised);
     },
   } as Adapter;
 };
@@ -253,6 +243,10 @@ function getProviders() {
       type: 'oauth',
       wellKnown: env.OIDC_WELL_KNOWN_URL,
       authorization: { params: { scope: 'openid email profile' } },
+      checks: env.OIDC_PKCE_ENABLED ? ['pkce'] : [],
+      client: env.OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG
+        ? { id_token_signed_response_alg: env.OIDC_ID_TOKEN_SIGNED_RESPONSE_ALG }
+        : undefined,
       allowDangerousEmailAccountLinking: env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING,
       idToken: true,
       profile(profile) {


### PR DESCRIPTION
# Description

While I was attempting to set up [Kanidm](https://github.com/kanidm/kanidm) to work with SplitPro I had hit a few roadblocks: 

1. Kanidm includes an `issued_token_type` field in its token response which isn't in the Prisma schema, causing a DB crash before the account could be created. Rather than adding another provider-specific case to `linkAccount`, this PR replaces the entire chain with a generic sanitisation pass using `Prisma.AccountScalarFieldEnum` as the source of truth. Any provider with non-standard fields now works without further changes.

2. Kanidm also enforces PKCE and ES256 by default, both of which were previously not supported by SplitPro. These can now be configured by optional env vars. I also added an example kanidm env config. 

To test these changes, I ran the updated code on my NAS in a Docker container and finally managed to authenticate with Kanidm. Disabling PKCE or defaulting to RS256 both fail on the default Kanidm config. 

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me
