### PR TITLE
fix: prevent expense name truncation in group expense list

### DIFF
--- a/src/components/AddExpense/AddExpensePage.tsx
+++ b/src/components/AddExpense/AddExpensePage.tsx
@@ -338,8 +338,13 @@ export const AddOrEditExpensePage: React.FC<{
                 <div className="flex flex-col items-center justify-center text-sm text-gray-400 sm:mt-4 sm:flex-row">
                   <p>{t(`ui.expense.${isNegative ? 'received_by' : 'paid_by'}`)}</p>
                   <PayerSelectionForm>
-                    <Button variant="ghost" className="text-primary h-8 px-1.5 py-0 text-base">
-                      {displayName(paidBy, currentUser?.id, 'dativus')}
+                    <Button
+                      variant="ghost"
+                      className="text-primary h-8 max-w-full min-w-0 justify-start px-1.5 py-0 text-base sm:max-w-none"
+                    >
+                      <span className="max-w-full truncate">
+                        {displayName(paidBy, currentUser?.id, 'dativus')}
+                      </span>
                     </Button>
                   </PayerSelectionForm>
                   <p>{t('ui.and')} </p>

--- a/src/components/AddExpense/SelectUserOrGroup.tsx
+++ b/src/components/AddExpense/SelectUserOrGroup.tsx
@@ -161,9 +161,9 @@ export const SelectUserOrGroup: React.FC<{
                 className="flex w-full items-center justify-between border-b border-gray-900 py-4"
                 onClick={() => handleFriendClick(f)}
               >
-                <div className="flex items-center gap-4">
+                <div className="flex min-w-0 items-center gap-4">
                   <EntityAvatar entity={f} size={35} />
-                  <div>{f.name ?? f.email}</div>
+                  <div className="truncate">{f.name ?? f.email}</div>
                 </div>
                 {participants.some((p) => p.id === f.id) ? (
                   <div>
@@ -186,9 +186,9 @@ export const SelectUserOrGroup: React.FC<{
                   className="border-b border-gray-900 py-4"
                   onClick={() => onGroupSelect(g.group)}
                 >
-                  <div className="flex items-center gap-4">
+                  <div className="flex min-w-0 items-center gap-4">
                     <EntityAvatar entity={g.group} size={35} />
-                    <p>{g.group.name}</p>
+                    <p className="truncate">{g.group.name}</p>
                   </div>
                 </button>
               ))}

--- a/src/components/AddExpense/SplitTypeSection.tsx
+++ b/src/components/AddExpense/SplitTypeSection.tsx
@@ -63,9 +63,9 @@ const PayerRow = ({ p, isPaying }: { p: Participant; isPaying: boolean }) => {
 
   return (
     <AppDrawerClose className="flex items-center justify-between px-2" onClick={onClick}>
-      <div className="flex items-center gap-1">
+      <div className="flex min-w-0 items-center gap-1">
         <EntityAvatar entity={p} size={30} />
-        <p className="ml-4">{displayName(p, currentUser?.id)}</p>
+        <p className="ml-4 truncate">{displayName(p, currentUser?.id)}</p>
       </div>
       {isPaying ? <Check className="h-6 w-6 text-cyan-500" /> : null}
     </AppDrawerClose>
@@ -434,10 +434,10 @@ export const UserAndAmount: React.FC<{ user: Participant; currency: CurrencyCode
   const shareAmount = paidBy?.id === user.id ? (user.amount ?? 0n) - amount : user.amount;
 
   return (
-    <div className="flex h-11 items-center gap-2">
+    <div className="flex h-11 min-w-0 flex-1 items-center gap-2">
       <EntityAvatar entity={user} size={30} />
-      <div className="flex flex-col items-start">
-        <p>{displayName(user, currentUser?.id)}</p>
+      <div className="flex min-w-0 flex-col">
+        <p className="truncate">{displayName(user, currentUser?.id)}</p>
         <p
           className={cn(
             canSplitScreenClosed || 'hidden',

--- a/src/components/AddExpense/UserInput.tsx
+++ b/src/components/AddExpense/UserInput.tsx
@@ -83,10 +83,10 @@ export const UserInput: React.FC<{
           p.id !== currentUser?.id ? (
             <div
               key={p.id}
-              className="flex items-center gap-2 rounded-full bg-slate-800 p-0.5 pr-4"
+              className="flex max-w-40 items-center gap-2 rounded-full bg-slate-800 p-0.5 pr-4"
             >
               <EntityAvatar entity={p} size={30} />
-              <p className="text-xs">{p.name ?? p.email}</p>
+              <p className="truncate text-xs">{p.name ?? p.email}</p>
             </div>
           ) : null,
         )

--- a/src/components/Expense/BalanceEntry.tsx
+++ b/src/components/Expense/BalanceEntry.tsx
@@ -24,9 +24,9 @@ export const BalanceEntry: React.FC<{
 
   return (
     <Link className="flex items-center justify-between" href={`${currentRoute}/${id}`}>
-      <div className="flex items-center gap-3">
+      <div className="flex min-w-0 items-center gap-3">
         <EntityAvatar entity={entity} size={35} />
-        <div className="text-foreground">{displayName(entity)}</div>
+        <div className="text-foreground truncate">{displayName(entity)}</div>
       </div>
       <div className="text-right" onClick={stopPropagation}>
         <ConvertibleBalance withText balances={balances} entityId={id} />

--- a/src/components/Expense/BalanceList.tsx
+++ b/src/components/Expense/BalanceList.tsx
@@ -76,10 +76,10 @@ export const BalanceList: React.FC<{
 
         return (
           <AccordionItem key={user.id} value={displayName(user)}>
-            <AccordionTrigger className="hover:no-underline">
-              <div className="flex items-center gap-3">
+            <AccordionTrigger className="overflow-hidden hover:no-underline">
+              <div className="mr-2 flex min-w-0 flex-1 items-center gap-3">
                 <EntityAvatar entity={user} />
-                <div className="text-foreground">
+                <div className="text-foreground line-clamp-2 min-w-0 break-words">
                   {displayName(user, userQuery.data?.id)}
                   {Object.values(total).every((amount) => 0n === amount) ? (
                     <span className="text-gray-400">

--- a/src/components/Expense/ExpenseList.tsx
+++ b/src/components/Expense/ExpenseList.tsx
@@ -110,7 +110,7 @@ const Expense: ExpenseComponent = ({ e, userId }) => {
         <CategoryIcon category={e.category} className="size-5 shrink-0 text-gray-400" />
         <div className="min-w-0 pe-1">
           <p className="truncate text-sm lg:text-base">{e.name}</p>
-          <p className="xs:max-w-full flex max-w-32 truncate text-center text-xs text-gray-500">
+          <p className="truncate text-xs text-gray-500">
             {displayName(e.paidByUser, userId)}{' '}
             {t(`ui.expense.user.${e.amount < 0n ? 'received' : 'paid'}`)} {toUIString(e.amount)}
           </p>
@@ -152,8 +152,8 @@ const Settlement: ExpenseComponent = ({ e, userId }) => {
         {toUIDate(e.expenseDate)}
       </div>
       <SettleupIcon className="size-5 shrink-0 text-gray-400" />
-      <div>
-        <p className="flex text-center text-sm text-gray-400">
+      <div className="min-w-0">
+        <p className="line-clamp-2 text-sm text-gray-400">
           {displayName(e.paidByUser, userId)}{' '}
           {t(`ui.expense.user.${e.amount < 0n ? 'received' : 'paid'}`)} {toUIString(e.amount)}{' '}
           {t('ui.expense.to')} {displayName(userDetails.data, userId)}
@@ -191,7 +191,7 @@ const CurrencyConversion: ExpenseComponent = ({ e, userId }) => {
             getCurrencyHelpersCached(e.conversionTo.currency).toUIString(e.conversionTo.amount)
           }
         </p>
-        <p className="flex text-center text-xs text-gray-500">
+        <p className="truncate text-xs text-gray-500">
           {t('ui.expense.for')} {displayName(e.paidByUser, userId)} {t('ui.and')}{' '}
           {displayName(userDetails.data, userId)}
         </p>

--- a/src/components/Expense/ExpenseList.tsx
+++ b/src/components/Expense/ExpenseList.tsx
@@ -103,13 +103,13 @@ const Expense: ExpenseComponent = ({ e, userId }) => {
 
   return (
     <>
-      <div className="flex items-center gap-4">
-        <div className="inline-block w-6 text-center text-xs text-gray-500">
+      <div className="flex min-w-0 items-center gap-4">
+        <div className="inline-block w-6 shrink-0 text-center text-xs text-gray-500">
           {toUIDate(e.expenseDate)}
         </div>
         <CategoryIcon category={e.category} className="size-5 shrink-0 text-gray-400" />
-        <div>
-          <p className="max-w-[180px] truncate text-sm lg:max-w-md lg:text-base">{e.name}</p>
+        <div className="min-w-0 pe-1">
+          <p className="truncate text-sm lg:text-base">{e.name}</p>
           <p className="xs:max-w-full flex max-w-32 truncate text-center text-xs text-gray-500">
             {displayName(e.paidByUser, userId)}{' '}
             {t(`ui.expense.user.${e.amount < 0n ? 'received' : 'paid'}`)} {toUIString(e.amount)}
@@ -178,13 +178,13 @@ const CurrencyConversion: ExpenseComponent = ({ e, userId }) => {
   const userDetails = api.user.getUserDetails.useQuery({ userId: receiverId! });
 
   return (
-    <div className="flex items-center gap-4">
-      <div className="inline-block w-6 text-center text-xs text-gray-500">
+    <div className="flex min-w-0 items-center gap-4">
+      <div className="inline-block w-6 shrink-0 text-center text-xs text-gray-500">
         {toUIDate(e.expenseDate)}
       </div>
       <CurrencyConversionIcon className="size-5 shrink-0 text-gray-400" />
-      <div>
-        <p className="max-w-[180px] truncate text-sm lg:max-w-md lg:text-base">
+      <div className="min-w-0">
+        <p className="truncate text-sm lg:text-base">
           {getCurrencyHelpersCached(e.currency).toUIString(e.amount)} ➡️{' '}
           {
             /* @ts-ignore */


### PR DESCRIPTION


# Description
Currently, long texts are cut off even if there is enough space.
<img width="300" height="450" alt="image" src="https://github.com/user-attachments/assets/0f0e6e23-adad-481d-b9a3-4ca801a3662b" />



# Demo
After replacing hardcoded max-w-[180px] with proper flexbox min-w-0 on the text container these bug could be fixed:

<img width="300" height="440" alt="image" src="https://github.com/user-attachments/assets/30db9df2-b9fc-4ef0-b51b-39fb293f8f83" />

# Checklist

- [ x ] I have read `CONTRIBUTING.md` in its entirety
- [ x ] I have performed a self-review of my own code
- [ not needed ] I have added unit tests to cover my changes
- [ x ] The last commit successfully passed pre-commit checks
- [ x ] Any AI code was thoroughly reviewed by me
