### PR TITLE
fix(docs): correct OIDC callback URL to use OIDC_NAME

### DIFF
--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -18,10 +18,18 @@ Provider-specific variables are listed in [CONFIGURATION](CONFIGURATION.md).
 
 ## OIDC callback
 
-For generic OIDC providers, configure the callback URL as:
+For generic OIDC providers, the callback URL uses the lowercased value of the
+`OIDC_NAME` env var as the provider segment of the path:
 
 ```
-https://<your-domain>/api/auth/callback/oidc
+https://<your-domain>/api/auth/callback/<provider-name>
+```
+
+`<provider-name>` defaults to `oidc` when `OIDC_NAME` is not set. For example,
+with `OIDC_NAME=tinyauth` the callback URL is:
+
+```
+https://<your-domain>/api/auth/callback/tinyauth
 ```
 
 ## Provider setup notes


### PR DESCRIPTION
## Description

The docs hardcoded `/api/auth/callback/oidc`, but the actual OIDC provider `id` is `env.OIDC_NAME?.toLowerCase() ?? 'oidc'` (`src/server/auth.ts:249`). Users setting `OIDC_NAME=tinyauth` therefore need `/api/auth/callback/tinyauth`, and the previous docs led them to configure the wrong redirect URI in their IdP.

Updated `docs/AUTHENTICATION.md` to document the parameterized form and include an example.

Closes #679

## Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [x] The last commit successfully passed pre-commit checks

> Note: `pnpm tsgo --noEmit` currently fails on `main` due to a pre-existing error in `src/components/group/AddMembers.tsx:89` (`sendInviteEmail` not in tRPC input type), unrelated to this docs-only change.