### PR TITLE
docs: document Web Push notification setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Create expenses with categories, currencies, dates, and receipt attachments. Spl
 
 ### 2) Application info
 
-SplitPro is a PWA and that is the recommended way to use the app. It supports push notifications for new expenses and updates.
+SplitPro is a PWA and that is the recommended way to use the app. It supports push notifications for new expenses and updates, but push delivery requires additional configuration. See [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
 
 ### 3) Groups
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -94,9 +94,17 @@ Used for magic-link login and invites.
 
 ### Web push notifications
 
-- `WEB_PUSH_PRIVATE_KEY`
-- `WEB_PUSH_PUBLIC_KEY`
-- `WEB_PUSH_EMAIL`
+Push notifications are disabled until VAPID keys are configured. Without them, the in-app notification toggle has no effect.
+
+To enable push notifications:
+
+1. Generate a VAPID keypair, either with `npx web-push generate-vapid-keys --json` or the online tool at https://vapidkeys.com
+2. Set these env vars in `.env`:
+   - `WEB_PUSH_PUBLIC_KEY` — generated public key
+   - `WEB_PUSH_PRIVATE_KEY` — generated private key
+   - `WEB_PUSH_EMAIL` — contact email as a bare address (e.g. `you@example.com`); the app prepends `mailto:` automatically
+3. Redeploy or restart your container.
+4. If you previously toggled notifications off in the PWA or system settings, re-enable them after redeploying.
 
 ### Feedback email
 


### PR DESCRIPTION
## Description

The README mentioned push notifications as a feature but gave no hint that they require VAPID keys, so users enabling the in-app notification toggle saw no notifications and no explanation (see issue thread).

Expanded the `Web push notifications` section in `docs/CONFIGURATION.md` with the full setup steps (VAPID key generation, env vars, redeploy, re-enable toggle). Trimmed the README to a one-line note that push delivery requires additional configuration, with a pointer to `docs/CONFIGURATION.md`.

Notable detail: `WEB_PUSH_EMAIL` is a bare email address — the app prepends `mailto:` automatically (`src/server/notification.ts:9`).

Closes #649

## Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [x] The last commit successfully passed pre-commit checks