### PR TITLE
feat: oauth autoredirect support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,10 @@ PLAID_COUNTRY_CODES=
 PLAID_INTERVAL_IN_DAYS=
 
 
+# Automatically redirect sign-in when exactly one OAuth provider is configured and no other
+# authentication providers are enabled
+OAUTH_AUTO_REDIRECT=false
+
 # Google Provider : https://next-auth.js.org/providers/google
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -67,6 +67,10 @@ Used for magic-link login and invites.
 
 ### OAuth providers
 
+#### Shared OAuth settings
+
+- `OAUTH_AUTO_REDIRECT`: Optional flag. When set to `true`, the sign-in page automatically redirects to the first configured OAuth provider. This applies to any configured OAuth provider, including Google, Authentik, Keycloak, and generic OIDC.
+
 #### Google
 
 - `GOOGLE_CLIENT_ID`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -69,7 +69,7 @@ Used for magic-link login and invites.
 
 #### Shared OAuth settings
 
-- `OAUTH_AUTO_REDIRECT`: Optional flag. When set to `true`, the sign-in page automatically redirects to the first configured OAuth provider. This applies to any configured OAuth provider, including Google, Authentik, Keycloak, and generic OIDC.
+- `OAUTH_AUTO_REDIRECT`: Optional flag. When set to `true`, the sign-in page automatically redirects when exactly one OAuth provider is configured and no other authentication providers are enabled. This applies to Google, Authentik, Keycloak, and generic OIDC.
 
 #### Google
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -71,6 +71,7 @@ export const env = createEnv({
     OIDC_CLIENT_SECRET: z.string().optional(),
     OIDC_WELL_KNOWN_URL: z.string().optional(),
     OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: z.boolean().default(false),
+    OAUTH_AUTO_REDIRECT: z.boolean().optional(),
     UPLOAD_MAX_FILE_SIZE_MB: z.coerce.number().int().positive().default(10),
   },
 
@@ -142,6 +143,7 @@ export const env = createEnv({
     OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: Boolean(
       JSON.parse(process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING || 'false'),
     ),
+    OAUTH_AUTO_REDIRECT: 'true' === process.env.OAUTH_AUTO_REDIRECT,
     UPLOAD_MAX_FILE_SIZE_MB: process.env.UPLOAD_MAX_FILE_SIZE_MB
       ? Number(process.env.UPLOAD_MAX_FILE_SIZE_MB)
       : 10,

--- a/src/env.ts
+++ b/src/env.ts
@@ -71,7 +71,7 @@ export const env = createEnv({
     OIDC_CLIENT_SECRET: z.string().optional(),
     OIDC_WELL_KNOWN_URL: z.string().optional(),
     OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: z.boolean().default(false),
-    OAUTH_AUTO_REDIRECT: z.boolean().optional(),
+    OAUTH_AUTO_REDIRECT: z.boolean().default(false),
     UPLOAD_MAX_FILE_SIZE_MB: z.coerce.number().int().positive().default(10),
   },
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -143,7 +143,7 @@ export const env = createEnv({
     OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: Boolean(
       JSON.parse(process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING || 'false'),
     ),
-    OAUTH_AUTO_REDIRECT: 'true' === process.env.OAUTH_AUTO_REDIRECT,
+    OAUTH_AUTO_REDIRECT: Boolean(JSON.parse(process.env.OAUTH_AUTO_REDIRECT || 'false')),
     UPLOAD_MAX_FILE_SIZE_MB: process.env.UPLOAD_MAX_FILE_SIZE_MB
       ? Number(process.env.UPLOAD_MAX_FILE_SIZE_MB)
       : 10,

--- a/src/pages/auth/signin.tsx
+++ b/src/pages/auth/signin.tsx
@@ -59,7 +59,8 @@ const Home: NextPage<{
   feedbackEmail: string;
   providers: ClientSafeProvider[];
   callbackUrl?: string;
-}> = ({ error, providers: serverProviders, feedbackEmail, callbackUrl }) => {
+  oauthAutoRedirect: boolean;
+}> = ({ error, providers: serverProviders, feedbackEmail, callbackUrl, oauthAutoRedirect }) => {
   const { t } = useTranslation();
   const [emailStatus, setEmailStatus] = useState<'idle' | 'sending' | 'success'>('idle');
   const [showVerificationStep, setShowVerificationStep] = useState(false);
@@ -109,6 +110,15 @@ const Home: NextPage<{
       }
     }
   }, [error, t]);
+
+  useEffect(() => {
+    if (oauthAutoRedirect && !showVerificationStep && providers.length > 0 && !isLoadingProviders) {
+      const oauthProvider = providers.find((provider) => 'oauth' === provider.type);
+      if (oauthProvider) {
+        void signIn(oauthProvider.id, { callbackUrl });
+      }
+    }
+  }, [oauthAutoRedirect, showVerificationStep, providers, isLoadingProviders, callbackUrl]);
 
   const onEmailSubmit = useCallback(async () => {
     setEmailStatus('sending');
@@ -293,6 +303,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       feedbackEmail: env.FEEDBACK_EMAIL ?? '',
       providers: Object.values(providers ?? {}),
       callbackUrl: callbackUrl && !Array.isArray(callbackUrl) ? callbackUrl : '',
+      oauthAutoRedirect: env.OAUTH_AUTO_REDIRECT,
     },
   };
 };

--- a/src/pages/auth/signin.tsx
+++ b/src/pages/auth/signin.tsx
@@ -112,11 +112,13 @@ const Home: NextPage<{
   }, [error, t]);
 
   useEffect(() => {
-    if (oauthAutoRedirect && !showVerificationStep && providers.length > 0 && !isLoadingProviders) {
-      const oauthProvider = providers.find((provider) => 'oauth' === provider.type);
-      if (oauthProvider) {
-        void signIn(oauthProvider.id, { callbackUrl });
-      }
+    const oauthProviders = providers.filter((provider) => 'oauth' === provider.type);
+    const shouldAutoRedirect =
+      oauthAutoRedirect && 1 === oauthProviders.length && 1 === providers.length;
+
+    const oauthProvider = oauthProviders[0];
+    if (shouldAutoRedirect && oauthProvider && !showVerificationStep && !isLoadingProviders) {
+      void signIn(oauthProvider.id, { callbackUrl });
     }
   }, [oauthAutoRedirect, showVerificationStep, providers, isLoadingProviders, callbackUrl]);
 

--- a/src/pages/auth/signin.tsx
+++ b/src/pages/auth/signin.tsx
@@ -113,14 +113,26 @@ const Home: NextPage<{
 
   useEffect(() => {
     const oauthProviders = providers.filter((provider) => 'oauth' === provider.type);
+    // SessionRequired indicates an unauthenticated route redirect, not a failed sign-in.
+    const hasSignInError = Boolean(error && 'SessionRequired' !== error);
     const shouldAutoRedirect =
-      oauthAutoRedirect && 1 === oauthProviders.length && 1 === providers.length;
+      oauthAutoRedirect && !hasSignInError && 1 === oauthProviders.length && 1 === providers.length;
 
     const oauthProvider = oauthProviders[0];
     if (shouldAutoRedirect && oauthProvider && !showVerificationStep && !isLoadingProviders) {
-      void signIn(oauthProvider.id, { callbackUrl });
+      void signIn(oauthProvider.id, { callbackUrl }).catch(() => {
+        toast.error(t('errors.signin_error'));
+      });
     }
-  }, [oauthAutoRedirect, showVerificationStep, providers, isLoadingProviders, callbackUrl]);
+  }, [
+    oauthAutoRedirect,
+    error,
+    showVerificationStep,
+    providers,
+    isLoadingProviders,
+    callbackUrl,
+    t,
+  ]);
 
   const onEmailSubmit = useCallback(async () => {
     setEmailStatus('sending');

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -283,6 +283,14 @@ export function validateAuthEnv() {
   console.log('Validating auth env');
   if (!process.env.SKIP_ENV_VALIDATION) {
     const providers = getProviders();
+    const oauthProviders = providers.filter((provider) => 'oauth' === provider.type);
+
+    if (env.OAUTH_AUTO_REDIRECT && (1 !== oauthProviders.length || 1 !== providers.length)) {
+      console.warn(
+        'OAUTH_AUTO_REDIRECT is enabled, but automatic redirection will not happen until exactly one OAuth provider and no other authentication providers are configured.',
+      );
+    }
+
     if (0 === providers.length) {
       throw new Error(
         'No authentication providers are configured, at least one is required. Learn more here: https://github.com/oss-apps/split-pro?tab=readme-ov-file#setting-up-the-environment',


### PR DESCRIPTION
# Description
Adds optional automatic redirect from the sign-in page to the first configured OAuth provider when `OAUTH_AUTO_REDIRECT=true`.

Let me know if any other changes/updates are needed.

# Demo
No UI screenshots included. Behavior change is:
- With `OAUTH_AUTO_REDIRECT=true` and at least one OAuth provider configured, visiting the sign-in page redirects immediately to the first configured OAuth provider.

# Checklist

- [X] I have read `CONTRIBUTING.md` in its entirety
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [X] The last commit successfully passed pre-commit checks
- [X] Any AI code was thoroughly reviewed by me


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional setting to automatically redirect sign-in when exactly one OAuth provider is configured.
  - Automatic redirection remains disabled by default and is skipped while verification or provider loading is active.
  - Sign-in failures during automatic redirection are reported with a notification.

- **Documentation**
  - Documented the automatic redirection setting and its configuration requirements.

- **Bug Fixes**
  - Added validation and warnings for unsupported automatic redirection configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->