### PR TITLE
fix: prevent prisma crash on OIDC accounts with non-standard fields

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,4 +1,5 @@
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { Prisma } from '@prisma/client';
 import { type GetServerSidePropsContext } from 'next';
 import { type DefaultSession, type NextAuthOptions, type User, getServerSession } from 'next-auth';
 import { type Adapter, type AdapterAccount, type AdapterUser } from 'next-auth/adapters';
@@ -78,25 +79,17 @@ const SplitProPrismaAdapter = (...args: Parameters<typeof PrismaAdapter>): Adapt
         throw new Error('Adapter is missing the linkAccount method.');
       }
 
-      // Keycloak and Gitlab provide some non-standard fields that do not exist in the prisma schema.
+      // OIDC providers can provide non-standard fields that do not exist in the prisma schema.
       // We strip them out before passing them on to the original adapter.
-      if (account.provider === 'keycloak') {
-        const {
-          'not-before-policy': _notBeforePolicy,
-          refresh_expires_in: _refresh_expires_in,
-          ...standardAccountData
-        } = account as AdapterAccount & Record<string, unknown>;
+      const knownAccountFields = new Set<string>(Object.values(Prisma.AccountScalarFieldEnum));
 
-        return originalLinkAccount(standardAccountData as AdapterAccount);
-      } else if (account.provider === 'gitlab') {
-        const { created_at: _createdAt, ...standardAccountData } = account as AdapterAccount &
-          Record<string, unknown>;
+      const sanitised = Object.fromEntries(
+        Object.entries(account as Record<string, unknown>).filter(([k]) =>
+          knownAccountFields.has(k),
+        ),
+      ) as AdapterAccount;
 
-        return originalLinkAccount(standardAccountData as AdapterAccount);
-      }
-
-      // Default: proceed directly
-      return originalLinkAccount(account);
+      return originalLinkAccount(sanitised);
     },
   } as Adapter;
 };


### PR DESCRIPTION
# Description

Kanidm includes an `issued_token_type` field in its token response which isn't in the Prisma schema, causing a DB crash before the account could be created. Rather than adding another provider-specific case to `linkAccount`, this PR replaces the entire chain with a generic sanitisation pass using `Prisma.AccountScalarFieldEnum` as the source of truth. Any provider with non-standard fields now works without further changes.

# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me

See #682 
