### PR TITLE
Fix link to CONTRIBUTING.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Thanks to @johanngrobe there is now also a Proxmox Community Script available [h
 
 ### Development and contributing
 
-See the [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) document.
+See the [CONTRIBUTING.md](CONTRIBUTING.md) document.
 
 ## Sponsors
 


### PR DESCRIPTION
# Description
The `README.md` points to `CONTRIBUTING.md` in the `docs/` directory, but `CONTRIBUTING.md` is at the root of the directory.

I didn't feel the need to add an issue, as this is a very small change.


# Checklist

- [x] I have read `CONTRIBUTING.md` in its entirety
- [x] I have performed a self-review of my own code
- [x] I have added unit tests to cover my changes (not needed)
- [x] The last commit successfully passed pre-commit checks
- [x] Any AI code was thoroughly reviewed by me


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the development contribution guide link in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->