### PR TITLE
fix: parse OIDC account linking flag as boolean

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -70,7 +70,7 @@ export const env = createEnv({
     OIDC_CLIENT_ID: z.string().optional(),
     OIDC_CLIENT_SECRET: z.string().optional(),
     OIDC_WELL_KNOWN_URL: z.string().optional(),
-    OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: z.boolean().optional(),
+    OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: z.boolean().default(false),
     UPLOAD_MAX_FILE_SIZE_MB: z.coerce.number().int().positive().default(10),
   },
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -139,7 +139,9 @@ export const env = createEnv({
     OIDC_CLIENT_ID: process.env.OIDC_CLIENT_ID,
     OIDC_CLIENT_SECRET: process.env.OIDC_CLIENT_SECRET,
     OIDC_WELL_KNOWN_URL: process.env.OIDC_WELL_KNOWN_URL,
-    OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: Boolean(process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING),
+    OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: Boolean(
+      JSON.parse(process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING || 'false'),
+    ),
     UPLOAD_MAX_FILE_SIZE_MB: process.env.UPLOAD_MAX_FILE_SIZE_MB
       ? Number(process.env.UPLOAD_MAX_FILE_SIZE_MB)
       : 10,


### PR DESCRIPTION
# Description
Parse OIDC_ALLOW_DANGEROUS_EMAIL_LINKING as a JSON boolean so "false" does not enable dangerous account linking.

# Checklist

- [X] I have read `CONTRIBUTING.md` in its entirety
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [X] The last commit successfully passed pre-commit checks
- [X] Any AI code was thoroughly reviewed by me


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the dangerous email-linking configuration setting.
  * The setting now defaults to disabled when not explicitly configured.
  * Configuration values are interpreted consistently, with invalid values safely falling back to disabled.
  * This reduces the risk of unintended email account linking caused by ambiguous environment values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->