### PR TITLE
fix: standardize boolean environment parsing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,10 @@ import { createJiti } from 'jiti';
 const jiti = createJiti(fileURLToPath(import.meta.url));
 import withSerwistInit from '@serwist/next';
 
+/** @type {typeof import('./src/utils/env')} */
+const envUtils = await jiti.import('./src/utils/env');
+const { parseEnvBoolean } = envUtils;
+
 /**
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially useful
  * for Docker builds.
@@ -14,7 +18,7 @@ await jiti.import('./src/env');
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: process.env.DOCKER_OUTPUT ? 'standalone' : undefined,
+  output: parseEnvBoolean(process.env.DOCKER_OUTPUT) ? 'standalone' : undefined,
   transpilePackages: ['@t3-oss/env-nextjs', '@t3-oss/env-core'],
   /**
    * If you are using `appDir` then you must comment the below `i18n` config out.

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,8 @@
 import { createEnv } from '@t3-oss/env-nextjs';
 import { z } from 'zod';
 
+import { parseEnvBoolean } from './utils/env';
+
 export const env = createEnv({
   /**
    * Specify your server-side environment variables schema here. This way you can ensure the app
@@ -93,23 +95,21 @@ export const env = createEnv({
       process.env.DATABASE_URL ??
       `postgresql://${process.env.POSTGRES_USER}:${process.env.POSTGRES_PASSWORD}@${process.env.POSTGRES_HOST}:${process.env.POSTGRES_PORT}`,
     NODE_ENV: process.env.NODE_ENV,
-    DOCKER_OUTPUT: Boolean(JSON.parse(process.env.DOCKER_OUTPUT || 'false')),
+    DOCKER_OUTPUT: parseEnvBoolean(process.env.DOCKER_OUTPUT),
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     NEXTAUTH_URL_INTERNAL: process.env.NEXTAUTH_URL_INTERNAL ?? process.env.NEXTAUTH_URL,
     CLEAR_CACHE_CRON_RULE: process.env.CLEAR_CACHE_CRON_RULE ?? '0 2 * * 0',
     CACHE_RETENTION_INTERVAL: process.env.CACHE_RETENTION_INTERVAL ?? '2 days',
-    ENABLE_SENDING_INVITES: 'true' === process.env.ENABLE_SENDING_INVITES,
-    DISABLE_EMAIL_SIGNUP: 'true' === process.env.DISABLE_EMAIL_SIGNUP,
-    INVITE_ONLY: 'true' === process.env.INVITE_ONLY,
+    ENABLE_SENDING_INVITES: parseEnvBoolean(process.env.ENABLE_SENDING_INVITES),
+    DISABLE_EMAIL_SIGNUP: parseEnvBoolean(process.env.DISABLE_EMAIL_SIGNUP),
+    INVITE_ONLY: parseEnvBoolean(process.env.INVITE_ONLY),
     FROM_EMAIL: process.env.FROM_EMAIL,
     EMAIL_SERVER_HOST: process.env.EMAIL_SERVER_HOST,
     EMAIL_SERVER_PORT: process.env.EMAIL_SERVER_PORT,
     EMAIL_SERVER_USER: process.env.EMAIL_SERVER_USER,
     EMAIL_SERVER_PASSWORD: process.env.EMAIL_SERVER_PASSWORD,
-    EMAIL_TLS_REJECT_UNAUTHORIZED: Boolean(
-      JSON.parse(process.env.EMAIL_TLS_REJECT_UNAUTHORIZED || 'true'),
-    ),
+    EMAIL_TLS_REJECT_UNAUTHORIZED: parseEnvBoolean(process.env.EMAIL_TLS_REJECT_UNAUTHORIZED, true),
     GOCARDLESS_COUNTRY: process.env.GOCARDLESS_COUNTRY,
     GOCARDLESS_SECRET_ID: process.env.GOCARDLESS_SECRET_ID,
     GOCARDLESS_SECRET_KEY: process.env.GOCARDLESS_SECRET_KEY,
@@ -139,8 +139,8 @@ export const env = createEnv({
     OIDC_CLIENT_ID: process.env.OIDC_CLIENT_ID,
     OIDC_CLIENT_SECRET: process.env.OIDC_CLIENT_SECRET,
     OIDC_WELL_KNOWN_URL: process.env.OIDC_WELL_KNOWN_URL,
-    OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: Boolean(
-      JSON.parse(process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING || 'false'),
+    OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: parseEnvBoolean(
+      process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING,
     ),
     UPLOAD_MAX_FILE_SIZE_MB: process.env.UPLOAD_MAX_FILE_SIZE_MB
       ? Number(process.env.UPLOAD_MAX_FILE_SIZE_MB)
@@ -152,7 +152,7 @@ export const env = createEnv({
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially
    * useful for Docker builds.
    */
-  skipValidation: Boolean(JSON.parse(process.env.SKIP_ENV_VALIDATION || 'false')),
+  skipValidation: parseEnvBoolean(process.env.SKIP_ENV_VALIDATION),
   /**
    * Makes it so that empty strings are treated as undefined. `SOME_VAR: z.string()` and
    * `SOME_VAR=''` will throw an error.

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -10,6 +10,7 @@ import KeycloakProvider from 'next-auth/providers/keycloak';
 
 import { env } from '~/env';
 import { db } from '~/server/db';
+import { parseEnvBoolean } from '~/utils/env';
 
 import { mailServerConfig, sendSignUpEmail } from './mailer';
 import { getBaseUrl } from '~/utils/api';
@@ -281,7 +282,7 @@ function getProviders() {
  */
 export function validateAuthEnv() {
   console.log('Validating auth env');
-  if (!process.env.SKIP_ENV_VALIDATION) {
+  if (!parseEnvBoolean(process.env.SKIP_ENV_VALIDATION)) {
     const providers = getProviders();
     if (0 === providers.length) {
       throw new Error(

--- a/src/tests/env.test.ts
+++ b/src/tests/env.test.ts
@@ -1,0 +1,27 @@
+import { parseEnvBoolean } from '../utils/env';
+
+describe('parseEnvBoolean', () => {
+  it.each([
+    ['1', true],
+    ['true', true],
+    ['TRUE', true],
+    ['  TrUe  ', true],
+    ['0', false],
+    ['false', false],
+    ['FALSE', false],
+    ['  FaLsE  ', false],
+  ])('parses %p as %p', (value, expected) => {
+    expect(parseEnvBoolean(value)).toBe(expected);
+  });
+
+  it.each([undefined, '', 'on', 'off', 'yes', '2'])('uses false for invalid value %p', (value) => {
+    expect(parseEnvBoolean(value)).toBe(false);
+  });
+
+  it.each([undefined, '', 'on', 'off', 'yes', '2'])(
+    'uses the supplied fallback for invalid value %p',
+    (value) => {
+      expect(parseEnvBoolean(value, true)).toBe(true);
+    },
+  );
+});

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,16 @@
+const TRUE_ENV_VALUES = new Set(['1', 'true']);
+const FALSE_ENV_VALUES = new Set(['0', 'false']);
+
+export const parseEnvBoolean = (value: string | undefined, fallback = false): boolean => {
+  const normalizedValue = value?.trim().toLowerCase();
+
+  if (TRUE_ENV_VALUES.has(normalizedValue ?? '')) {
+    return true;
+  }
+
+  if (FALSE_ENV_VALUES.has(normalizedValue ?? '')) {
+    return false;
+  }
+
+  return fallback;
+};


### PR DESCRIPTION
# Description

Standardizes boolean environment-variable parsing with a shared parseEnvBoolean utility.

- Supports case-insensitive, whitespace-trimmed 1/true and 0/false.
- Replaces inconsistent JSON.parse, direct string comparison, and raw truthiness checks.
- Applies the parser to app environment configuration, Next standalone output, and auth environment-validation bypass.
- Keeps EMAIL_TLS_REJECT_UNAUTHORIZED secure by default: invalid or unset values retain certificate verification.

# Checklist

- [X] I have read `CONTRIBUTING.md` in its entirety
- [X] I have performed a self-review of my own code
- [X] I have added unit tests to cover my changes
- [X] The last commit successfully passed pre-commit checks
- [X] Any AI code was thoroughly reviewed by me


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of boolean configuration settings across deployment, authentication, email, invitations, and identity integrations.
  - Values such as `true`, `false`, `1`, and `0` are now interpreted consistently, regardless of capitalization or surrounding whitespace.
  - Invalid or missing values use safe defaults instead of being enabled unintentionally.
  - Docker standalone output is enabled only when explicitly set to a true value.

- **Tests**
  - Added coverage for valid, invalid, missing, and fallback boolean configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->