### PR TITLE
fix: parse oauth auto redirect environment flag

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -143,7 +143,7 @@ export const env = createEnv({
     OIDC_ALLOW_DANGEROUS_EMAIL_LINKING: parseEnvBoolean(
       process.env.OIDC_ALLOW_DANGEROUS_EMAIL_LINKING,
     ),
-    OAUTH_AUTO_REDIRECT: Boolean(JSON.parse(process.env.OAUTH_AUTO_REDIRECT || 'false')),
+    OAUTH_AUTO_REDIRECT: parseEnvBoolean(process.env.OAUTH_AUTO_REDIRECT),
     UPLOAD_MAX_FILE_SIZE_MB: process.env.UPLOAD_MAX_FILE_SIZE_MB
       ? Number(process.env.UPLOAD_MAX_FILE_SIZE_MB)
       : 10,


### PR DESCRIPTION
# Description

Last update to parse the new OAUTH_AUTO_REDIRECT value with the parseEnvBoolean function.

# Checklist

- [X] I have read `CONTRIBUTING.md` in its entirety
- [X] I have performed a self-review of my own code
- [ ] I have added unit tests to cover my changes
- [X] The last commit successfully passed pre-commit checks
- [X] Any AI code was thoroughly reviewed by me


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of the automatic OAuth redirect setting by consistently interpreting its configured true/false value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->