### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,4 +176,4 @@ We are grateful for the support of our sponsors.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=oss-apps/split-pro&type=Date)](https://star-history.com/#oss-apps/split-pro&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=oss-apps/split-pro&type=Date)](https://star-history.dera.page/#oss-apps/split-pro&Date)


### PR DESCRIPTION
The star history chart in the README currently fails to load because its previous source depends on the GitHub stargazer API, which now blocks those requests. This change points the chart to a working alternative so visitors can see the project's star history again. No other references are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart image and link to use the current Star History website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->