### PR TITLE
fix: handle group member errors and split defaults

### DIFF
--- a/src/components/AddExpense/SelectUserOrGroup.tsx
+++ b/src/components/AddExpense/SelectUserOrGroup.tsx
@@ -8,10 +8,16 @@ import React, { useCallback } from 'react';
 import { z } from 'zod';
 
 import { useAddExpenseStore } from '~/store/addStore';
+import { deserializeDefaultSplit } from '~/lib/defaultSplit';
 import { api } from '~/utils/api';
 
 import { EntityAvatar } from '../ui/avatar';
 import { Button } from '../ui/button';
+
+type SelectableGroup = Group & {
+  groupUsers: (GroupUser & { user: User })[];
+  defaultSplit?: Parameters<typeof deserializeDefaultSplit>[0];
+};
 
 export const SelectUserOrGroup: React.FC<{
   enableSendingInvites: boolean;
@@ -20,8 +26,14 @@ export const SelectUserOrGroup: React.FC<{
   const nameOrEmail = useAddExpenseStore((s) => s.nameOrEmail);
   const participants = useAddExpenseStore((s) => s.participants);
   const group = useAddExpenseStore((s) => s.group);
-  const { addOrUpdateParticipant, removeParticipant, setNameOrEmail, setGroup, setParticipants } =
-    useAddExpenseStore((s) => s.actions);
+  const {
+    addOrUpdateParticipant,
+    applySplitPreset,
+    removeParticipant,
+    setNameOrEmail,
+    setGroup,
+    setParticipants,
+  } = useAddExpenseStore((s) => s.actions);
 
   const friendsQuery = api.user.getFriends.useQuery();
   const groupsQuery = api.group.getAllGroups.useQuery();
@@ -76,7 +88,7 @@ export const SelectUserOrGroup: React.FC<{
   );
 
   const onGroupSelect = useCallback(
-    (group: Group & { groupUsers: (GroupUser & { user: User })[] }) => {
+    (group: SelectableGroup) => {
       setGroup(group);
       const { currentUser } = useAddExpenseStore.getState();
       if (currentUser) {
@@ -85,9 +97,13 @@ export const SelectUserOrGroup: React.FC<{
           ...group.groupUsers.map((gu) => gu.user).filter((u) => u.id !== currentUser.id),
         ]);
       }
+      const parsedDefaultSplit = deserializeDefaultSplit(group.defaultSplit);
+      if (parsedDefaultSplit) {
+        applySplitPreset(parsedDefaultSplit.splitType, parsedDefaultSplit.shares);
+      }
       setNameOrEmail('');
     },
-    [setGroup, setParticipants, setNameOrEmail],
+    [applySplitPreset, setGroup, setParticipants, setNameOrEmail],
   );
 
   const handleAddEmailClickFalse = useCallback(() => onAddEmailClick(false), [onAddEmailClick]);

--- a/src/components/group/AddMembers.tsx
+++ b/src/components/group/AddMembers.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, SendIcon } from 'lucide-react';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import { z } from 'zod';
+import { toast } from 'sonner';
 
 import { Button } from '~/components/ui/button';
 import { AppDrawer } from '~/components/ui/drawer';
@@ -72,6 +73,9 @@ const AddMembers: React.FC<{
         {
           onSuccess: () => {
             utils.group.getGroupDetails.invalidate({ groupId: group.id }).catch(console.error);
+          },
+          onError: (error) => {
+            toast.error(error.message);
           },
         },
       );

--- a/src/lib/groupMembership.ts
+++ b/src/lib/groupMembership.ts
@@ -1,0 +1,8 @@
+export const getDuplicateGroupMemberIds = (
+  existingUserIds: readonly number[],
+  requestedUserIds: readonly number[],
+) => {
+  const existingIds = new Set(existingUserIds);
+
+  return [...new Set(requestedUserIds.filter((userId) => existingIds.has(userId)))];
+};

--- a/src/server/api/routers/group.ts
+++ b/src/server/api/routers/group.ts
@@ -3,6 +3,7 @@ import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
 import { simplifyDebts } from '~/lib/simplify';
+import { getDuplicateGroupMemberIds } from '~/lib/groupMembership';
 import { createTRPCRouter, groupProcedure, protectedProcedure } from '~/server/api/trpc';
 import { sendGroupSimplifyDebtsToggleNotification } from '~/server/api/services/notificationService';
 import { SplitType } from '@prisma/client';
@@ -46,12 +47,24 @@ export const groupRouter = createTRPCRouter({
                 user: true,
               },
             },
+            groupDefaultSplit: true,
           },
         },
       },
     });
 
-    return groups;
+    return groups.map((groupUser) => ({
+      ...groupUser,
+      group: {
+        ...groupUser.group,
+        defaultSplit: groupUser.group.groupDefaultSplit
+          ? parseSerializedDefaultSplit(
+              groupUser.group.groupDefaultSplit.splitType,
+              groupUser.group.groupDefaultSplit.shares,
+            )
+          : null,
+      },
+    }));
   }),
 
   getAllGroupsWithBalances: protectedProcedure
@@ -187,6 +200,25 @@ export const groupRouter = createTRPCRouter({
   addMembers: groupProcedure
     .input(z.object({ userIds: z.array(z.number()) }))
     .mutation(async ({ input, ctx }) => {
+      const existingMembers = await ctx.db.groupUser.findMany({
+        where: {
+          groupId: input.groupId,
+          userId: { in: input.userIds },
+        },
+        select: { userId: true },
+      });
+      const duplicateUserIds = getDuplicateGroupMemberIds(
+        existingMembers.map((member) => member.userId),
+        input.userIds,
+      );
+
+      if (duplicateUserIds.length > 0) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'One or more selected users are already members of this group',
+        });
+      }
+
       const groupUsers = await ctx.db.groupUser.createMany({
         data: input.userIds.map((userId) => ({
           groupId: input.groupId,

--- a/src/tests/addStore.test.ts
+++ b/src/tests/addStore.test.ts
@@ -1187,3 +1187,25 @@ describe('useAddExpenseStore sign preservation on edit (#658)', () => {
     expect(state.amount).toBe(20001n);
   });
 });
+
+describe('useAddExpenseStore group default split (#720)', () => {
+  const { actions } = useAddExpenseStore.getState();
+
+  beforeEach(() => {
+    actions.resetState();
+    actions.setParticipants([user1, user2]);
+    actions.setAmount(10000n);
+  });
+
+  it('applies the selected group default split to its participants', () => {
+    actions.applySplitPreset(SplitType.SHARE, {
+      [user1.id]: 2n,
+      [user2.id]: 3n,
+    });
+
+    const state = useAddExpenseStore.getState();
+    expect(state.splitType).toBe(SplitType.SHARE);
+    expect(state.splitShares[user1.id]?.[SplitType.SHARE]).toBe(2n);
+    expect(state.splitShares[user2.id]?.[SplitType.SHARE]).toBe(3n);
+  });
+});

--- a/src/tests/groupMembership.test.ts
+++ b/src/tests/groupMembership.test.ts
@@ -1,0 +1,11 @@
+import { getDuplicateGroupMemberIds } from '~/lib/groupMembership';
+
+describe('getDuplicateGroupMemberIds', () => {
+  it('returns each already-member user once', () => {
+    expect(getDuplicateGroupMemberIds([1, 2], [2, 2, 3, 1])).toEqual([2, 1]);
+  });
+
+  it('returns no duplicates for new members', () => {
+    expect(getDuplicateGroupMemberIds([1, 2], [3, 4])).toEqual([]);
+  });
+});

--- a/src/tests/number.test.ts
+++ b/src/tests/number.test.ts
@@ -36,6 +36,14 @@ describe('getCurrencyHelpers', () => {
           expect(toUIString(value)).toBe('$0.07');
         });
 
+        it('should preserve a one-cent amount when formatted from input text', () => {
+          const { format, toSafeBigInt } = getCurrencyHelpers({ locale, currency });
+          const value = toSafeBigInt('0.01');
+
+          expect(format('0.01', { hideSymbol: true })).toBe('0.01');
+          expect(toUIString(value, false, true)).toBe('0.01');
+        });
+
         it.each([
           [12345n, '$123.45'],
           [-12345n, '-$123.45'],


### PR DESCRIPTION
## Summary
- report duplicate group-member additions as a user-facing conflict instead of a Prisma failure
- load and apply group default splits when selecting a group from the global Add flow
- add regression coverage for duplicate IDs, group split presets, and one-cent formatting

## Issues
- Closes #723
- Closes #720
- Related to #724; the one-cent conversion path is covered and currently passes, so no speculative formatter change was made.

## Verification
- `pnpm test --runInBand`
- `pnpm tsgo --noEmit`
- `pnpm prettier --check .`
- `pnpm build`
- targeted oxlint: zero errors

The repository-wide lint command terminated due to an out-of-memory condition; targeted linting completed with warnings only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group default split presets are now applied automatically when selecting a group.
  * Group details now include saved default split settings.

* **Bug Fixes**
  * Prevented adding people who are already members of a group.
  * Added clear error notifications when adding members fails.
  * Preserved one-cent amounts correctly during formatting and display.

* **Tests**
  * Added coverage for split presets, duplicate memberships, and precise currency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->