### PR TITLE
fix: show error when adding duplicate group member

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -134,6 +134,7 @@
     "email_required": "Email is required",
     "feedback_min_length": "Feedback should be at least 10 characters",
     "feedback_required": "Feedback is required",
+    "add_member_failed": "Failed to add member to the group",
     "group_name_update_failed": "Error in updating group name",
     "import_failed": "Error importing file",
     "invalid_currency_code": "Invalid currency code {{code}}",

--- a/src/components/group/AddMembers.tsx
+++ b/src/components/group/AddMembers.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx';
 import { CheckIcon, SendIcon } from 'lucide-react';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'next-i18next';
+import { toast } from 'sonner';
 import { z } from 'zod';
 
 import { Button } from '~/components/ui/button';
@@ -73,12 +74,13 @@ const AddMembers: React.FC<{
           onSuccess: () => {
             utils.group.getGroupDetails.invalidate({ groupId: group.id }).catch(console.error);
           },
+          onError: () => toast.error(t('errors.add_member_failed')),
         },
       );
       setOpen(false);
       setUserIds({});
     },
-    [addMembersMutation, group.id, utils],
+    [addMembersMutation, group.id, t, utils],
   );
 
   const isEmail = z.string().email().safeParse(inputValue);


### PR DESCRIPTION
## Summary
- show a toast when adding a group member fails
- add the English translation for the error message

Closes #723

## Verification
- prettier check passed
- type checking passed
- oxlint passed with existing warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear error notification when adding members to a group fails.
  * Provided an English translation for the failure message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->