### PR TITLE
fix: preserve cents in equal splits

### DIFF
--- a/src/store/addStore.ts
+++ b/src/store/addStore.ts
@@ -348,7 +348,10 @@ export function calculateParticipantSplit(
 
     if (canSplitScreenClosed) {
       let penniesLeft = updatedParticipants.reduce((acc, p) => acc + (p.amount ?? 0n), 0n);
-      const participantsToPick = updatedParticipants.filter((p) => p.amount);
+      const participantsToPick =
+        splitType === SplitType.EQUAL
+          ? updatedParticipants.filter((p) => p.id !== paidBy?.id && 0n !== getSplitShare(p))
+          : updatedParticipants.filter((p) => p.amount);
       const seed =
         cyrb128(
           `${participantsToPick

--- a/src/tests/addStore.test.ts
+++ b/src/tests/addStore.test.ts
@@ -590,6 +590,7 @@ describe('calculateParticipantSplit', () => {
       const totalAmount = result.participants.reduce((sum, p) => sum + (p.amount ?? 0n), 0n);
 
       expect(totalAmount).toBe(0n);
+      expect(result.participants.some((p) => -1n === p.amount)).toBe(true);
     });
   });
 });

--- a/src/tests/number.test.ts
+++ b/src/tests/number.test.ts
@@ -70,6 +70,18 @@ describe('getCurrencyHelpers', () => {
           expect(toUIString(value)).toBe(expected);
         });
       });
+
+      describe('NZD', () => {
+        const { toSafeBigInt, toUIString } = getCurrencyHelpers({
+          locale: 'en-NZ',
+          currency: 'NZD',
+        });
+
+        it('preserves one cent when parsing and displaying an amount', () => {
+          expect(toSafeBigInt('0.01')).toBe(1n);
+          expect(toUIString(1n, false, true)).toBe('0.01');
+        });
+      });
     });
 
     describe('bg-BG locale', () => {


### PR DESCRIPTION
## Summary
- allocate one-cent remainders to a participating non-payer in equal splits
- add regression coverage for one-cent splits and NZD formatting

Closes #724

## Verification
- 
> split@0.1.0 test /home/krokosik/kod/split-pro
> jest -- --runInBand --roots src (369 tests passed)
- 
- Prettier check passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved equal-split calculations so penny adjustments exclude the payer and participants with no share.
  - Preserved accurate one-cent amounts in equal splits and NZD currency formatting.

- **Tests**
  - Added coverage for penny distribution and one-cent NZD parsing and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->