### PR TITLE
docs: support rootless Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,9 @@ COPY --from=base /app/.next/static ./.next/static
 COPY --from=base /app/public ./public
 COPY --from=base /app/prisma/migrations ./prisma/migrations
 
+# Prepare persistent receipt storage for non-root container users.
+RUN mkdir -p /app/uploads && chown node:node /app/uploads
+
 # set this so it throws error where starting server
 ENV SKIP_ENV_VALIDATION="false"
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,6 +27,38 @@ This will start the PostgreSQL database and the Splitpro application containers.
 
 6. Access the Splitpro application by visiting `http://localhost:3000` in your web browser.
 
+## Rootless application deployment
+
+The image includes a non-root `node` user, but keeps the default Dockerfile user unchanged for
+compatibility. To run only the Splitpro application as that user, add `user: node` to the
+`splitpro` service in `docker/prod/compose.yml`:
+
+```yaml
+services:
+  splitpro:
+    user: node
+```
+
+You can use the numeric identity instead:
+
+```yaml
+services:
+  splitpro:
+    user: '1000:1000'
+```
+
+Receipts are stored in `/app/uploads`. The image prepares this directory for the `node` user, so
+new named volumes work without additional setup. If you use a bind mount, make sure the host
+directory is writable by UID/GID `1000:1000` before starting the application:
+
+```bash
+mkdir -p uploads
+chown -R 1000:1000 uploads
+```
+
+This runs the application process without root privileges. Running Docker itself in rootless mode
+is a separate host-level configuration.
+
 ### Minimal .env example
 
 ```bash


### PR DESCRIPTION
## Summary
- prepare `/app/uploads` for the image's existing non-root `node` user
- document running the SplitPro service as `node` or UID/GID `1000:1000` via Compose
- document bind-mount ownership requirements and distinguish app-level rootless execution from rootless Docker

## Validation
- `pnpm prettier --check .`
- `pnpm lint` (0 errors; existing warnings)
- `pnpm tsgo --noEmit`
- `pnpm test --runInBand` (184 passed)
- `pnpm build` (passes with the existing top-level-await warning in `src/server/db.ts`)

This PR was prepared with AI assistance and reviewed for scope and correctness.