### PR TITLE
fix(i18n): format short dates with a single Intl call

### DIFF
--- a/src/components/AddExpense/BankTransactions/BankTransactionItem.tsx
+++ b/src/components/AddExpense/BankTransactions/BankTransactionItem.tsx
@@ -14,7 +14,7 @@ export const BankTransactionItem: React.FC<{
   groupName: string;
   multipleTransactions: TransactionAddInputModel[];
 }> = ({ index, alreadyAdded, item, onTransactionRowClick, groupName, multipleTransactions }) => {
-  const { t, toUIDate } = useTranslationWithUtils();
+  const { t, toUIDateParts } = useTranslationWithUtils();
   const [isHovered, setIsHovered] = useState(false);
 
   const createCheckboxHandler = useCallback(() => {
@@ -84,13 +84,11 @@ export const BankTransactionItem: React.FC<{
         onClick={hasMultiple ? createCheckboxHandler : createClickHandler}
       >
         <div className="text-xs text-gray-500">
-          {toUIDate(new Date(item.bookingDate), { useToday: true })
-            .split(' ')
-            .map((d) => (
-              <div className="text-center" key={d}>
-                {d}
-              </div>
-            ))}
+          {toUIDateParts(new Date(item.bookingDate), { useToday: true }).map((part) => (
+            <div className="text-center" key={part}>
+              {part}
+            </div>
+          ))}
         </div>
         <div>
           <p

--- a/src/hooks/useTranslationWithUtils.ts
+++ b/src/hooks/useTranslationWithUtils.ts
@@ -10,6 +10,7 @@ import {
   getCurrencyName as gCN,
   generateSplitDescription as gsd,
   toUIDate as tUD,
+  toUIDateParts as tUDP,
 } from '~/utils/strings';
 
 export const useTranslationWithUtils = (
@@ -18,6 +19,7 @@ export const useTranslationWithUtils = (
   displayName: typeof displayName;
   generateSplitDescription: typeof generateSplitDescription;
   toUIDate: typeof toUIDate;
+  toUIDateParts: typeof toUIDateParts;
   getCurrencyName: typeof getCurrencyName;
   getCurrencyHelpersCached: (currency: string) => CurrencyHelpersType;
 } => {
@@ -41,6 +43,11 @@ export const useTranslationWithUtils = (
 
   const toUIDate = useCallback(
     (...args: ParametersExceptTranslation<typeof tUD>): string => tUD(translation.t, ...args),
+    [translation.t],
+  );
+
+  const toUIDateParts = useCallback(
+    (...args: ParametersExceptTranslation<typeof tUDP>): string[] => tUDP(translation.t, ...args),
     [translation.t],
   );
 
@@ -68,6 +75,7 @@ export const useTranslationWithUtils = (
       displayName,
       generateSplitDescription,
       toUIDate,
+      toUIDateParts,
       getCurrencyName,
       getCurrencyHelpersCached,
     }),
@@ -76,6 +84,7 @@ export const useTranslationWithUtils = (
       displayName,
       generateSplitDescription,
       toUIDate,
+      toUIDateParts,
       getCurrencyName,
       getCurrencyHelpersCached,
     ],

--- a/src/tests/strings.test.ts
+++ b/src/tests/strings.test.ts
@@ -1,0 +1,53 @@
+import { type TFunction } from 'next-i18next';
+import { toUIDateParts } from '../utils/strings';
+
+// oxlint-disable-next-line no-unsafe-type-assertion -- the util only needs `t` for one key
+const tFor = (locale: string) =>
+  ((key: string) => ({ res: `today (${key})`, usedLng: locale })) as unknown as TFunction;
+
+const date = new Date('2026-07-05T12:00:00Z');
+
+const supportedLocales = [
+  'en',
+  'de',
+  'fr',
+  'it',
+  'cs',
+  'nl',
+  'pl',
+  'pt-PT',
+  'pt-BR',
+  'sv',
+  'es',
+  'es-MX',
+  'es-AR',
+  'id',
+  'hu',
+  'zh-Hant',
+];
+
+describe('toUIDateParts', () => {
+  it.each([
+    ['en', ['Jul', '05']],
+    ['de', ['05', 'Jul']],
+    ['fr', ['05', 'juil.']],
+    ['cs', ['05.', 'čvc']],
+    ['pt-BR', ['05', 'jul.']],
+    ['pt-PT', ['05', 'jul.']],
+    ['es-MX', ['05', 'jul']],
+    ['hu', ['júl.', '05']],
+    ['zh-Hant', ['7月', '05日']],
+  ])('returns the month and the day of %p in locale order', (locale, expected) => {
+    expect(toUIDateParts(tFor(locale), date)).toStrictEqual(expected);
+  });
+
+  it.each(supportedLocales)('always returns two parts for %p', (locale) => {
+    expect(toUIDateParts(tFor(locale), date)).toHaveLength(2);
+  });
+
+  it('returns the translated today as a single part', () => {
+    expect(toUIDateParts(tFor('pt-BR'), new Date(), { useToday: true })).toStrictEqual([
+      'today (ui.today)',
+    ]);
+  });
+});

--- a/src/tests/strings.test.ts
+++ b/src/tests/strings.test.ts
@@ -5,7 +5,7 @@ import { toUIDateParts } from '../utils/strings';
 const tFor = (locale: string) =>
   ((key: string) => ({ res: `today (${key})`, usedLng: locale })) as unknown as TFunction;
 
-const date = new Date('2026-07-05T12:00:00Z');
+const date = new Date(2026, 6, 5, 12);
 
 const supportedLocales = [
   'en',

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -37,12 +37,10 @@ export const toUIDate = (
     }).format(date);
   }
 
-  const day = new Intl.DateTimeFormat(todayTranslation.usedLng, { day: '2-digit' }).format(date);
-  const monthName = new Intl.DateTimeFormat(todayTranslation.usedLng, { month: 'short' })
-    .format(date)
-    .replace('.', '');
-
-  return `${monthName} ${day}`;
+  return new Intl.DateTimeFormat(todayTranslation.usedLng, {
+    month: 'short',
+    day: '2-digit',
+  }).format(date);
 };
 
 export function generateSplitDescription(

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -20,6 +20,8 @@ export const displayName = (
   return user?.name ?? user?.email ?? '';
 };
 
+const SHORT_DATE_OPTIONS: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit' };
+
 export const toUIDate = (
   t: TFunction,
   date: Date,
@@ -37,10 +39,30 @@ export const toUIDate = (
     }).format(date);
   }
 
-  return new Intl.DateTimeFormat(todayTranslation.usedLng, {
-    month: 'short',
-    day: '2-digit',
-  }).format(date);
+  return new Intl.DateTimeFormat(todayTranslation.usedLng, SHORT_DATE_OPTIONS).format(date);
+};
+
+/**
+ * The month and the day of `toUIDate`'s short form as separate values, ordered the way the
+ * locale orders them, for renderings that put them on their own lines.
+ */
+export const toUIDateParts = (t: TFunction, date: Date, { useToday = false } = {}): string[] => {
+  const todayTranslation = t('ui.today', { returnDetails: true });
+
+  if (useToday && isToday(date)) {
+    return [todayTranslation.res];
+  }
+
+  const locale = todayTranslation.usedLng;
+  const fields = {
+    month: new Intl.DateTimeFormat(locale, { month: 'short' }).format(date),
+    day: new Intl.DateTimeFormat(locale, { day: '2-digit' }).format(date),
+  };
+
+  // The combined format only says which field comes first, each field is formatted alone
+  return new Intl.DateTimeFormat(locale, SHORT_DATE_OPTIONS)
+    .formatToParts(date)
+    .flatMap((part) => ('month' === part.type || 'day' === part.type ? [fields[part.type]] : []));
 };
 
 export function generateSplitDescription(


### PR DESCRIPTION
## What

`toUIDate` built the short (no-year) date by formatting the month and the day in two
separate `Intl.DateTimeFormat` calls and concatenating them as `` `${monthName} ${day}` ``.
That hardcodes English field order and spacing, so every locale that orders or spaces the
short date differently rendered it incorrectly:

| locale | before | after |
| --- | --- | --- |
| en | `Aug 05` | `Aug 05` (unchanged) |
| de | `Aug 05` | `05. Aug.` |
| fr | `août 05` | `05 août` |
| sv | `aug 05` | `05 aug.` |
| hu | `aug 05` | `aug. 05.` |
| pt-BR | `ago 05` | `05 de ago.` |
| cs | `srp 05.` | `05. 8.` |
| zh-Hant | `8月 05日` | `8月05日` |

Letting `Intl.DateTimeFormat` emit month and day in a single call gives the correct order,
spacing and abbreviation dots per CLDR, and removes the `.replace('.', '')` hack that was
stripping a dot several locales actually need.

Two deliberate choices:

- `day: '2-digit'` is kept, so **English output is byte-identical** to before.
- `cs` switches from the abbreviated month name to CLDR's numeric short form, and `pt-PT` /
  `es-MX` / `es-AR` do the same (`05/07`, `05-jul`) — that is what the locale data
  specifies for a month+day skeleton. Happy to reassemble the parts by hand if you'd rather
  keep abbreviated month names everywhere.

The `year: true` branch already used a single `dateStyle: 'long'` call and is untouched.

## Second commit: the stacked date in the bank transaction list

`BankTransactionItem` renders that date as a stacked badge, and it did so by splitting the
formatted string on ASCII spaces — which only works for the English `<month> <day>` shape.
Once the string is locale-shaped, `pt-BR` (`05 de ago.`) would render three lines with `de`
alone on one, and `pt-PT`, `es-MX`, `es-AR` and `zh-*` would collapse to a single line.

The intent there is one line per field, so instead of inferring lines from the shape of a
string, `toUIDate` gains a sibling:

```ts
toUIDateParts(t, date, { useToday }) // → ['Jul', '05'] | ['05', 'Jul'] | ['7月', '05日'] | …
```

It formats the month and the day on their own and uses the combined skeleton only to ask
the locale which field comes first, so separators never end up on a line of their own. All
17 locales in `next-i18next.config.js` return exactly two parts. `toUIDate` itself is
unchanged for the eight call sites that want one line.

## Testing

Added `src/tests/strings.test.ts`: per-locale expectations for `toUIDateParts` (`en`, `de`,
`fr`, `cs`, `pt-BR`, `pt-PT`, `es-MX`, `hu`, `zh-Hant`), a check that every configured
locale yields exactly two parts, and the `useToday` case.

Locally: `pnpm test` (7 suites, 210 tests), `pnpm lint` (same 288 warnings as `main`, none
added), `pnpm tsgo --noEmit` and `pnpm prettier --check` all pass. I did not run
`pnpm build`, which needs the app env.

## AI disclosure

Per the AI contribution policy: this patch and this description were drafted with AI
assistance (Claude Code). The diff plus the per-locale `Intl` output above were reviewed
and verified before submitting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date formatting for dates without a year.
  * Preserved localized short month names and two-digit day formatting for more consistent display.
  * Corrected month-and-day ordering to match each locale.
  * Dates occurring today can now display as “Today” where supported.
  * Improved transaction date display by presenting localized date components consistently.
  * Ensured date components are displayed correctly across supported language and regional settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->